### PR TITLE
feat: add lint command to validate changelog format

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 - Automatically fixes changelogs that have missing or out-of-order sections in [Unreleased], ensuring all standard sections are present and in the correct order
 - Benchmarks for EnsureUnreleasedSections to measure allocations per operation and enforce regression baselines
+- Add lint command to validate changelog format (--lint, --additional-sections, --fix)
 ### Fixed
 ### Changed
 - Dependencies - Updated Meziantou.Analyzer to 2.0.219

--- a/src/Credfeto.ChangeLog.Cmd/Options.cs
+++ b/src/Credfeto.ChangeLog.Cmd/Options.cs
@@ -93,4 +93,7 @@ public sealed class Options
 
     [Option(longName: "additional-sections", Required = false, Separator = ',', HelpText = "Additional change type sections allowed in unreleased")]
     public IEnumerable<string> AdditionalSections { get; init; } = [];
+
+    [Option(longName: "fix", Required = false, HelpText = "When used with --lint, rewrite the file to fix formatting issues")]
+    public bool Fix { get; init; }
 }

--- a/src/Credfeto.ChangeLog.Cmd/Options.cs
+++ b/src/Credfeto.ChangeLog.Cmd/Options.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using CommandLine;
 
@@ -80,4 +81,16 @@ public sealed class Options
         HelpText = "Prints the unreleased section to the console."
     )]
     public bool DisplayUnreleased { get; init; }
+
+    [Option(
+        shortName: 'l',
+        longName: "lint",
+        Group = "Commands",
+        Required = false,
+        HelpText = "Lint the changelog for correctness"
+    )]
+    public bool Lint { get; init; }
+
+    [Option(longName: "additional-sections", Required = false, Separator = ',', HelpText = "Additional change type sections allowed in unreleased")]
+    public IEnumerable<string> AdditionalSections { get; init; } = [];
 }

--- a/src/Credfeto.ChangeLog.Cmd/Program.cs
+++ b/src/Credfeto.ChangeLog.Cmd/Program.cs
@@ -94,10 +94,11 @@ internal static class Program
         Console.WriteLine($"Using Changelog {changeLog}");
 
         IReadOnlyList<string> additionalSections = [.. options.AdditionalSections];
+        IReadOnlyCollection<string>? additionalSectionsArg = additionalSections.Count > 0 ? additionalSections : null;
 
         IReadOnlyList<LintError> errors = await ChangeLogLinter.LintFileAsync(
             changeLogFileName: changeLog,
-            additionalSections: additionalSections.Count > 0 ? additionalSections : null,
+            additionalSections: additionalSectionsArg,
             cancellationToken: cancellationToken
         );
 
@@ -111,6 +112,39 @@ internal static class Program
         foreach (LintError error in errors)
         {
             Console.WriteLine($"Line {error.LineNumber}: {error.Message}");
+        }
+
+        if (options.Fix)
+        {
+            Console.WriteLine("Applying fixes...");
+
+            await ChangeLogFixer.FixFileAsync(
+                changeLogFileName: changeLog,
+                additionalSections: additionalSectionsArg,
+                cancellationToken: cancellationToken
+            );
+
+            Console.WriteLine("Fixed. Re-linting...");
+
+            IReadOnlyList<LintError> remainingErrors = await ChangeLogLinter.LintFileAsync(
+                changeLogFileName: changeLog,
+                additionalSections: additionalSectionsArg,
+                cancellationToken: cancellationToken
+            );
+
+            if (remainingErrors.Count == 0)
+            {
+                Console.WriteLine("Changelog is valid after fix");
+
+                return;
+            }
+
+            Console.WriteLine("Remaining errors after fix:");
+
+            foreach (LintError error in remainingErrors)
+            {
+                Console.WriteLine($"Line {error.LineNumber}: {error.Message}");
+            }
         }
 
         throw new ChangeLogInvalidFailedException("Changelog has lint errors");

--- a/src/Credfeto.ChangeLog.Cmd/Program.cs
+++ b/src/Credfeto.ChangeLog.Cmd/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
+using Credfeto.ChangeLog;
 using Credfeto.ChangeLog.Cmd.Exceptions;
 
 namespace Credfeto.ChangeLog.Cmd;
@@ -77,7 +78,42 @@ internal static class Program
             return;
         }
 
+        if (options.Lint)
+        {
+            await LintChangeLogAsync(options: options, cancellationToken: cancellationToken);
+
+            return;
+        }
+
         throw new InvalidOptionsException();
+    }
+
+    private static async Task LintChangeLogAsync(Options options, CancellationToken cancellationToken)
+    {
+        string changeLog = FindChangeLog(options);
+        Console.WriteLine($"Using Changelog {changeLog}");
+
+        IReadOnlyList<string> additionalSections = [.. options.AdditionalSections];
+
+        IReadOnlyList<LintError> errors = await ChangeLogLinter.LintFileAsync(
+            changeLogFileName: changeLog,
+            additionalSections: additionalSections.Count > 0 ? additionalSections : null,
+            cancellationToken: cancellationToken
+        );
+
+        if (errors.Count == 0)
+        {
+            Console.WriteLine("Changelog is valid");
+
+            return;
+        }
+
+        foreach (LintError error in errors)
+        {
+            Console.WriteLine($"Line {error.LineNumber}: {error.Message}");
+        }
+
+        throw new ChangeLogInvalidFailedException("Changelog has lint errors");
     }
 
     private static async Task OutputUnreleasedContentAsync(Options options, CancellationToken cancellationToken)

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.ChangeLog.Tests;
+
+public sealed class ChangeLogFixerTests : TestBase
+{
+    private const string ValidChangeLog =
+        """
+        # Changelog
+
+        ## [Unreleased]
+        ### Security
+        ### Added
+        ### Fixed
+        ### Changed
+        ### Removed
+        ### Deployment Changes
+
+        ## [1.0.0] - 2024-01-01
+        ### Added
+        - Initial release
+
+        ## [0.0.0] - Project created
+        """;
+
+    [Fact]
+    public void AlreadyValidChangelog_RemainsValid()
+    {
+        string result = ChangeLogFixer.Fix(ValidChangeLog);
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(result);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void BlankLineAfterHeading_IsRemoved()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+
+            - an entry
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        string result = ChangeLogFixer.Fix(changeLog);
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(result);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void MissingRequiredSection_IsAdded()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Added
+            - an entry
+
+            ## [0.0.0] - Project created
+            """;
+
+        string result = ChangeLogFixer.Fix(changeLog);
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(result);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void OutOfOrderSections_AreReordered()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Added
+            - an entry
+            ### Security
+
+            ## [0.0.0] - Project created
+            """;
+
+        string result = ChangeLogFixer.Fix(changeLog);
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(result);
+        Assert.Empty(errors);
+    }
+}

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogLinterTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogLinterTests.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.ChangeLog.Tests;
+
+public sealed class ChangeLogLinterTests : TestBase
+{
+    private const string ValidChangeLog =
+        """
+        # Changelog
+
+        ## [Unreleased]
+        ### Security
+        ### Added
+        ### Fixed
+        ### Changed
+        ### Removed
+        ### Deployment Changes
+
+        ## [1.0.0] - 2024-01-01
+        ### Added
+        - Initial release
+
+        ## [0.0.0] - Project created
+        """;
+
+    [Fact]
+    public void ValidChangelog_ReturnsNoErrors()
+    {
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(ValidChangeLog);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void MissingUnreleasedSection_ReturnsError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [1.0.0] - 2024-01-01
+            ### Added
+            - Initial release
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.Contains(errors, e => e.Message.Contains(value: "[Unreleased]", comparisonType: StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MissingRequiredSection_ReturnsError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [1.0.0] - 2024-01-01
+            ### Added
+            - Initial release
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.Contains(
+            errors,
+            e =>
+                e.Message.Contains(value: "### Added", comparisonType: StringComparison.Ordinal)
+                && e.Message.Contains(value: "Missing", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void DuplicateSection_ReturnsError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            - First added
+            ### Added
+            - Duplicate added
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.Contains(
+            errors,
+            e =>
+                e.Message.Contains(value: "### Added", comparisonType: StringComparison.Ordinal)
+                && e.Message.Contains(value: "duplicated", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void UnknownSection_ReturnsError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+            ### Custom
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.Contains(
+            errors,
+            e =>
+                e.Message.Contains(value: "### Custom", comparisonType: StringComparison.Ordinal)
+                && e.Message.Contains(value: "Unknown", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void UnknownSection_AllowedViaAdditionalSections_ReturnsNoError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+            ### Custom
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(content: changeLog, additionalSections: ["Custom"]);
+
+        Assert.DoesNotContain(
+            errors,
+            e =>
+                e.Message.Contains(value: "### Custom", comparisonType: StringComparison.Ordinal)
+                && e.Message.Contains(value: "Unknown", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void BlankLineAfterHeading_ReturnsError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+
+            - item
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.Contains(
+            errors,
+            e => e.Message.Contains(value: "Blank line after heading '### Added'", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void NoBlankLineAfterHeading_ReturnsNoError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            - item
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.DoesNotContain(
+            errors,
+            e => e.Message.Contains(value: "Blank line after heading", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void InvalidVersionHeader_ReturnsError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [not-a-version] - 2024-01-01
+            ### Added
+            - Initial release
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.Contains(
+            errors,
+            e =>
+                e.Message.Contains(value: "not-a-version", comparisonType: StringComparison.Ordinal)
+                && e.Message.Contains(value: "Invalid version", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void ValidVersionsInOrder_ReturnsNoErrors()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [2.0.0] - 2024-03-01
+            ### Added
+            - Release 2
+
+            ## [1.0.0] - 2024-02-01
+            ### Added
+            - Release 1
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.DoesNotContain(
+            errors,
+            e => e.Message.Contains(value: "descending order", comparisonType: StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void VersionsOutOfOrder_ReturnsError()
+    {
+        const string changeLog =
+            """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [1.0.0] - 2024-02-01
+            ### Added
+            - Release 1
+
+            ## [2.0.0] - 2024-03-01
+            ### Added
+            - Release 2
+
+            ## [0.0.0] - Project created
+            """;
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(changeLog);
+
+        Assert.Contains(
+            errors,
+            e =>
+                e.Message.Contains(value: "2.0.0", comparisonType: StringComparison.Ordinal)
+                && e.Message.Contains(value: "descending order", comparisonType: StringComparison.Ordinal)
+        );
+    }
+}

--- a/src/Credfeto.ChangeLog/ChangeLogFixer.cs
+++ b/src/Credfeto.ChangeLog/ChangeLogFixer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Credfeto.ChangeLog;
+
+public static class ChangeLogFixer
+{
+    private const string SubHeadingPrefix = "### ";
+
+    public static async ValueTask FixFileAsync(
+        string changeLogFileName,
+        IReadOnlyCollection<string>? additionalSections,
+        CancellationToken cancellationToken
+    )
+    {
+        string content = await File.ReadAllTextAsync(
+            path: changeLogFileName,
+            encoding: Encoding.UTF8,
+            cancellationToken: cancellationToken
+        );
+
+        string fixed_ = Fix(content: content, additionalSections: additionalSections);
+
+        await File.WriteAllTextAsync(
+            path: changeLogFileName,
+            contents: fixed_,
+            encoding: Encoding.UTF8,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public static string Fix(string content, IReadOnlyCollection<string>? additionalSections = null)
+    {
+        string result = ChangeLogUpdater.EnsureUnreleasedSections(content);
+
+        return RemoveBlankLinesAfterHeadings(result);
+    }
+
+    private static string RemoveBlankLinesAfterHeadings(string content)
+    {
+        string[] lines = content.Split('\n');
+        List<string> output = new(lines.Length);
+        int i = 0;
+
+        while (i < lines.Length)
+        {
+            string line = lines[i].TrimEnd('\r');
+            output.Add(line);
+            i++;
+
+            if (
+                line.StartsWith(value: SubHeadingPrefix, comparisonType: StringComparison.Ordinal)
+                && i < lines.Length
+                && string.IsNullOrWhiteSpace(lines[i])
+            )
+            {
+                i++;
+            }
+        }
+
+        return string.Join(separator: Environment.NewLine, values: output).Trim();
+    }
+}

--- a/src/Credfeto.ChangeLog/ChangeLogLinter.cs
+++ b/src/Credfeto.ChangeLog/ChangeLogLinter.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Credfeto.ChangeLog;
+
+public static class ChangeLogLinter
+{
+    private static readonly string[] RequiredSections =
+    [
+        "Security",
+        "Added",
+        "Fixed",
+        "Changed",
+        "Removed",
+        "Deployment Changes",
+    ];
+
+    private const string UnreleasedHeader = "## [Unreleased]";
+    private const string SubHeadingPrefix = "### ";
+    private const string VersionHeaderPrefix = "## [";
+
+    public static async ValueTask<IReadOnlyList<LintError>> LintFileAsync(
+        string changeLogFileName,
+        IReadOnlyCollection<string>? additionalSections,
+        CancellationToken cancellationToken
+    )
+    {
+        string content = await File.ReadAllTextAsync(
+            path: changeLogFileName,
+            encoding: Encoding.UTF8,
+            cancellationToken: cancellationToken
+        );
+
+        return Lint(content: content, additionalSections: additionalSections);
+    }
+
+    public static IReadOnlyList<LintError> Lint(string content, IReadOnlyCollection<string>? additionalSections = null)
+    {
+        List<LintError> errors = [];
+
+        string[] lines = NormalizeLines(content);
+
+        CheckUnreleasedSectionPresent(lines: lines, errors: errors, additionalSections: additionalSections);
+
+        CheckBlankLineAfterHeadings(lines: lines, errors: errors);
+
+        CheckVersionHeaders(lines: lines, errors: errors);
+
+        return errors;
+    }
+
+    private static string[] NormalizeLines(string content)
+    {
+        string[] lines = content.Split('\n');
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            lines[i] = lines[i].TrimEnd('\r');
+        }
+
+        return lines;
+    }
+
+    private static void CheckUnreleasedSectionPresent(
+        string[] lines,
+        List<LintError> errors,
+        IReadOnlyCollection<string>? additionalSections
+    )
+    {
+        int unreleasedLineIndex = FindUnreleasedLine(lines);
+
+        if (unreleasedLineIndex == -1)
+        {
+            errors.Add(new LintError(LineNumber: 1, Message: "Missing [Unreleased] section"));
+
+            return;
+        }
+
+        CheckRequiredSectionsInUnreleased(
+            lines: lines,
+            unreleasedLineIndex: unreleasedLineIndex,
+            errors: errors,
+            additionalSections: additionalSections
+        );
+    }
+
+    private static int FindUnreleasedLine(string[] lines)
+    {
+        for (int i = 0; i < lines.Length; i++)
+        {
+            if (StringComparer.Ordinal.Equals(x: lines[i], y: UnreleasedHeader))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static void CheckRequiredSectionsInUnreleased(
+        string[] lines,
+        int unreleasedLineIndex,
+        List<LintError> errors,
+        IReadOnlyCollection<string>? additionalSections
+    )
+    {
+        int unreleasedEnd = FindUnreleasedEnd(lines: lines, unreleasedStart: unreleasedLineIndex);
+
+        List<(string Name, int LineNumber)> foundHeadings = CollectSubHeadings(
+            lines: lines,
+            start: unreleasedLineIndex + 1,
+            end: unreleasedEnd
+        );
+
+        CheckDuplicateSections(foundHeadings: foundHeadings, errors: errors);
+
+        CheckUnknownSections(foundHeadings: foundHeadings, errors: errors, additionalSections: additionalSections);
+
+        CheckRequiredSectionOrderAndPresence(
+            foundHeadings: foundHeadings,
+            unreleasedLineNumber: unreleasedLineIndex + 1,
+            errors: errors
+        );
+    }
+
+    private static void CheckDuplicateSections(
+        List<(string Name, int LineNumber)> foundHeadings,
+        List<LintError> errors
+    )
+    {
+        HashSet<string> seenSections = new(StringComparer.Ordinal);
+
+        foreach ((string name, int lineNumber) in foundHeadings)
+        {
+            if (!seenSections.Add(name))
+            {
+                errors.Add(
+                    new LintError(
+                        LineNumber: lineNumber,
+                        Message: $"Section '### {name}' is duplicated in [Unreleased]"
+                    )
+                );
+            }
+        }
+    }
+
+    private static void CheckUnknownSections(
+        List<(string Name, int LineNumber)> foundHeadings,
+        List<LintError> errors,
+        IReadOnlyCollection<string>? additionalSections
+    )
+    {
+        foreach ((string name, int lineNumber) in foundHeadings)
+        {
+            if (!IsKnownSection(name: name, additionalSections: additionalSections))
+            {
+                errors.Add(
+                    new LintError(
+                        LineNumber: lineNumber,
+                        Message: $"Unknown section '### {name}' in [Unreleased]"
+                    )
+                );
+            }
+        }
+    }
+
+    private static void CheckRequiredSectionOrderAndPresence(
+        List<(string Name, int LineNumber)> foundHeadings,
+        int unreleasedLineNumber,
+        List<LintError> errors
+    )
+    {
+        List<(string Name, int LineNumber)> foundRequired = GetFirstOccurrencesOfRequired(foundHeadings);
+        int lastFoundIndex = -1;
+
+        foreach (string requiredSection in RequiredSections)
+        {
+            int foundPos = FindInList(list: foundRequired, name: requiredSection);
+
+            if (foundPos == -1)
+            {
+                errors.Add(
+                    new LintError(
+                        LineNumber: unreleasedLineNumber,
+                        Message: $"Missing required section '### {requiredSection}' in [Unreleased]"
+                    )
+                );
+            }
+            else if (foundPos < lastFoundIndex)
+            {
+                errors.Add(
+                    new LintError(
+                        LineNumber: foundRequired[foundPos].LineNumber,
+                        Message: $"Section '### {requiredSection}' is out of order in [Unreleased]"
+                    )
+                );
+            }
+            else
+            {
+                lastFoundIndex = foundPos;
+            }
+        }
+    }
+
+    private static List<(string Name, int LineNumber)> GetFirstOccurrencesOfRequired(
+        List<(string Name, int LineNumber)> foundHeadings
+    )
+    {
+        List<(string Name, int LineNumber)> result = [];
+        HashSet<string> seen = new(StringComparer.Ordinal);
+
+        foreach ((string name, int lineNumber) in foundHeadings)
+        {
+            if (IsRequiredSection(name) && seen.Add(name))
+            {
+                result.Add((name, lineNumber));
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsRequiredSection(string name)
+    {
+        return RequiredSections.Any(required => StringComparer.Ordinal.Equals(x: required, y: name));
+    }
+
+    private static int FindInList(List<(string Name, int LineNumber)> list, string name)
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (StringComparer.Ordinal.Equals(x: list[i].Name, y: name))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsKnownSection(string name, IReadOnlyCollection<string>? additionalSections)
+    {
+        if (IsRequiredSection(name))
+        {
+            return true;
+        }
+
+        return additionalSections is not null
+            && additionalSections.Any(additional => StringComparer.Ordinal.Equals(x: additional, y: name));
+    }
+
+    private static List<(string Name, int LineNumber)> CollectSubHeadings(string[] lines, int start, int end)
+    {
+        List<(string Name, int LineNumber)> result = [];
+
+        for (int i = start; i < end; i++)
+        {
+            if (lines[i].StartsWith(value: SubHeadingPrefix, comparisonType: StringComparison.Ordinal))
+            {
+                string name = lines[i][SubHeadingPrefix.Length..];
+                result.Add((name, i + 1)); // 1-based line number
+            }
+        }
+
+        return result;
+    }
+
+    private static int FindUnreleasedEnd(string[] lines, int unreleasedStart)
+    {
+        for (int i = unreleasedStart + 1; i < lines.Length; i++)
+        {
+            if (
+                lines[i].StartsWith(value: VersionHeaderPrefix, comparisonType: StringComparison.Ordinal)
+                && !StringComparer.Ordinal.Equals(x: lines[i], y: UnreleasedHeader)
+            )
+            {
+                return i;
+            }
+        }
+
+        return lines.Length;
+    }
+
+    private static void CheckBlankLineAfterHeadings(string[] lines, List<LintError> errors)
+    {
+        for (int i = 0; i < lines.Length - 1; i++)
+        {
+            if (!lines[i].StartsWith(value: SubHeadingPrefix, comparisonType: StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(lines[i + 1]))
+            {
+                continue;
+            }
+
+            // Find the next non-empty line after the blank
+            int nextNonEmpty = i + 2;
+
+            while (nextNonEmpty < lines.Length && string.IsNullOrWhiteSpace(lines[nextNonEmpty]))
+            {
+                nextNonEmpty++;
+            }
+
+            if (nextNonEmpty >= lines.Length)
+            {
+                continue;
+            }
+
+            // A blank line between a ### heading and another section (### or ##) is acceptable formatting
+            if (
+                lines[nextNonEmpty].StartsWith(value: SubHeadingPrefix, comparisonType: StringComparison.Ordinal)
+                || lines[nextNonEmpty].StartsWith(value: VersionHeaderPrefix, comparisonType: StringComparison.Ordinal)
+            )
+            {
+                continue;
+            }
+
+            string name = lines[i][SubHeadingPrefix.Length..];
+            errors.Add(
+                new LintError(
+                    LineNumber: i + 1, // 1-based
+                    Message: $"Blank line after heading '### {name}'"
+                )
+            );
+        }
+    }
+
+    private static void CheckVersionHeaders(string[] lines, List<LintError> errors)
+    {
+        List<(Version ParsedVersion, int LineNumber, string OriginalVersion)> versions = [];
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string line = lines[i];
+
+            if (
+                !line.StartsWith(value: VersionHeaderPrefix, comparisonType: StringComparison.Ordinal)
+                || StringComparer.Ordinal.Equals(x: line, y: UnreleasedHeader)
+            )
+            {
+                continue;
+            }
+
+            int closeBracket = line.IndexOf(value: ']', startIndex: VersionHeaderPrefix.Length);
+
+            if (closeBracket == -1)
+            {
+                continue;
+            }
+
+            string versionStr = line[VersionHeaderPrefix.Length..closeBracket];
+            int lineNumber = i + 1; // 1-based
+
+            if (!IsValidVersion(versionStr))
+            {
+                errors.Add(
+                    new LintError(
+                        LineNumber: lineNumber,
+                        Message: $"Invalid version '{versionStr}' — must be a valid semver version"
+                    )
+                );
+
+                continue;
+            }
+
+            if (Version.TryParse(input: versionStr, result: out Version? parsed))
+            {
+                versions.Add((parsed, lineNumber, versionStr));
+            }
+        }
+
+        CheckVersionsDescendingOrder(versions: versions, errors: errors);
+    }
+
+    private static void CheckVersionsDescendingOrder(
+        List<(Version ParsedVersion, int LineNumber, string OriginalVersion)> versions,
+        List<LintError> errors
+    )
+    {
+        for (int i = 1; i < versions.Count; i++)
+        {
+            if (versions[i].ParsedVersion >= versions[i - 1].ParsedVersion)
+            {
+                errors.Add(
+                    new LintError(
+                        LineNumber: versions[i].LineNumber,
+                        Message: $"Version '{versions[i].OriginalVersion}' is not in descending order"
+                    )
+                );
+            }
+        }
+    }
+
+    private static bool IsValidVersion(string versionStr)
+    {
+        if (!Version.TryParse(input: versionStr, result: out Version? parsed))
+        {
+            return false;
+        }
+
+        // Require at least 3 parts (Major.Minor.Build)
+        return parsed.Build >= 0;
+    }
+}

--- a/src/Credfeto.ChangeLog/ChangeLogLinter.cs
+++ b/src/Credfeto.ChangeLog/ChangeLogLinter.cs
@@ -20,6 +20,8 @@ public static class ChangeLogLinter
         "Deployment Changes",
     ];
 
+    private static readonly string[] KnownOptionalSections = ["Deprecated"];
+
     private const string UnreleasedHeader = "## [Unreleased]";
     private const string SubHeadingPrefix = "### ";
     private const string VersionHeaderPrefix = "## [";
@@ -246,6 +248,11 @@ public static class ChangeLogLinter
     private static bool IsKnownSection(string name, IReadOnlyCollection<string>? additionalSections)
     {
         if (IsRequiredSection(name))
+        {
+            return true;
+        }
+
+        if (KnownOptionalSections.Any(optional => StringComparer.Ordinal.Equals(x: optional, y: name)))
         {
             return true;
         }

--- a/src/Credfeto.ChangeLog/LintError.cs
+++ b/src/Credfeto.ChangeLog/LintError.cs
@@ -1,0 +1,6 @@
+using System.Diagnostics;
+
+namespace Credfeto.ChangeLog;
+
+[DebuggerDisplay("Line {LineNumber}: {Message}")]
+public sealed record LintError(int LineNumber, string Message);


### PR DESCRIPTION
Closes #259

## Summary

Adds `--lint` (`-l`) to validate a changelog and `--fix` to automatically rewrite it in the correct format.

**New files:**
- `Credfeto.ChangeLog/LintError.cs` — record type `(int LineNumber, string Message)`
- `Credfeto.ChangeLog/ChangeLogLinter.cs` — static linting class with `Lint()` and `LintFileAsync()`
- `Credfeto.ChangeLog/ChangeLogFixer.cs` — static fixer class with `Fix()` and `FixFileAsync()`

**Modified files:**
- `Options.cs` — added `-l`/`--lint`, `--additional-sections`, and `--fix` options
- `Program.cs` — added `LintChangeLogAsync` dispatch
- `CHANGELOG.md` — entry added for this feature
- `.markdownlintignore` — exclude `CHANGELOG.md` from markdownlint (per AI instructions)

## Checks performed by `--lint`

1. `[Unreleased]` section is present
2. Required headings present in the correct order, no duplicates, no unknown extras: `Security`, `Added`, `Fixed`, `Changed`, `Removed`, `Deployment Changes` (`Deprecated` is recognised as optional)
3. No blank line immediately after a `### ` heading
4. All release version numbers parse as valid semver (`major.minor.patch[.build]`)
5. Releases listed in descending version order

## Fix behaviour (`--lint --fix`)

When `--fix` is combined with `--lint`:
1. Calls `ChangeLogUpdater.EnsureUnreleasedSections` to add missing/reorder headings
2. Removes blank lines immediately after `### ` headings
3. Re-lints and reports any errors that could not be automatically fixed (e.g. invalid version numbers, out-of-order releases)

## CLI usage

```sh
# Lint using auto-detected changelog
credfeto-changelog-manager --lint

# Lint with extra allowed sections
credfeto-changelog-manager --lint --additional-sections "Performance,Breaking"

# Lint and auto-fix what can be fixed
credfeto-changelog-manager --lint --fix
```

## Tests

- 11 tests in `ChangeLogLinterTests.cs` covering all lint checks and edge cases
- 4 tests in `ChangeLogFixerTests.cs` covering fix scenarios

All 146 tests pass on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)