### PR TITLE
feat: maintain preamble URLs in changelog headers when fixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - ChangeLogLanguageFactory is now a non-static class implementing IChangeLogLanguageFactory; language code changed from 'keep-a-changelog' to 'en'
 - Refactored service layer: IChangeLogStorage reduced to LoadAsync/SaveAsync; ChangeLogLanguage moved to method parameters; ChangeLogLanguageFactory made non-static implementing IChangeLogLanguageFactory with English constant renamed from KeepAChangelog to English
 - Maintain the keepachangelog.com and semver.org preamble URLs in changelog headers when fixing
+- replace CountOccurrences helper with source-generated regex in ChangeLogFixerTests
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Extracted FindUnreleasedStart as a shared extension method; replaced duplicated IsRelease private method with IsVersionHeader extension
 - ChangeLogLanguageFactory is now a non-static class implementing IChangeLogLanguageFactory; language code changed from 'keep-a-changelog' to 'en'
 - Refactored service layer: IChangeLogStorage reduced to LoadAsync/SaveAsync; ChangeLogLanguage moved to method parameters; ChangeLogLanguageFactory made non-static implementing IChangeLogLanguageFactory with English constant renamed from KeepAChangelog to English
+- Maintain the keepachangelog.com and semver.org preamble URLs in changelog headers when fixing
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - add service interfaces IChangeLogReader, IChangeLogLinter, IChangeLogFixer, IChangeLogUpdater with file-backed implementations injectable via DI
 - Mock-based unit tests for ChangeLogReader, ChangeLogFixer, ChangeLogLinter, ChangeLogUpdater services using NSubstitute
 - DI registration tests in ChangeLogSetupTests verifying all services are resolvable via AddChangeLog
+- Ensure preamble is inserted on every changelog edit operation (AddEntry, RemoveEntry, CreateRelease, EnsureUnreleasedSections), not only during Fix
 ### Fixed
 ### Changed
 - ChangeLogSections: added static FrozenSet<string> KnownSections pre-built from Order, replacing per-call HashSet allocation in BuildNewUnreleasedContent

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Credfeto.ChangeLog.Models;
@@ -130,5 +131,119 @@ public sealed class ChangeLogFixerTests : TestBase
 
         IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(Parse(result), Language);
         Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void MissingPreamble_IsAdded()
+    {
+        const string changeLog = """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Deprecated
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        string result = Serialise(ChangeLogFixer.Fix(Parse(changeLog), Language));
+
+        Assert.Contains(
+            "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),",
+            result,
+            StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).",
+            result,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void ExistingPreamble_IsNotDuplicated()
+    {
+        const string changeLog = """
+            # Changelog
+            All notable changes to this project will be documented in this file.
+
+            The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+            and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Deprecated
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        string result = Serialise(ChangeLogFixer.Fix(Parse(changeLog), Language));
+
+        int count = CountOccurrences(
+            result,
+            "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),"
+        );
+        Assert.Equal(expected: 1, actual: count);
+    }
+
+    [Fact]
+    public void MissingPreamble_IsInsertedBeforeHtmlComment()
+    {
+        const string changeLog = """
+            # Changelog
+
+            <!--
+            Please ADD ALL Changes to the UNRELEASED SECTION
+            -->
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+            ### Fixed
+            ### Changed
+            ### Deprecated
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        string result = Serialise(ChangeLogFixer.Fix(Parse(changeLog), Language));
+
+        int preambleIndex = result.IndexOf("The format is based on", StringComparison.Ordinal);
+        int commentIndex = result.IndexOf("<!--", StringComparison.Ordinal);
+        Assert.True(preambleIndex < commentIndex, "Preamble should appear before HTML comment");
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+
+        while (
+            (
+                index = text.IndexOf(
+                    value: pattern,
+                    startIndex: index,
+                    comparisonType: StringComparison.Ordinal
+                )
+            ) >= 0
+        )
+        {
+            count++;
+            index += pattern.Length;
+        }
+
+        return count;
     }
 }

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Credfeto.ChangeLog.Models;
 using Credfeto.ChangeLog.Services;
 using FunFair.Test.Common;
@@ -23,7 +24,7 @@ namespace Credfeto.ChangeLog.Tests;
     checkId: "CA2012:UseValueTasksCorrectly",
     Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
 )]
-public sealed class ChangeLogFixerTests : TestBase
+public sealed partial class ChangeLogFixerTests : TestBase
 {
     private const string VALID_CHANGE_LOG = """
         # Changelog
@@ -189,10 +190,7 @@ public sealed class ChangeLogFixerTests : TestBase
 
         string result = Serialise(ChangeLogFixer.Fix(Parse(changeLog), Language));
 
-        int count = CountOccurrences(
-            result,
-            "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),"
-        );
+        int count = PreambleFormatLineRegex().Count(result);
         Assert.Equal(expected: 1, actual: count);
     }
 
@@ -225,25 +223,10 @@ public sealed class ChangeLogFixerTests : TestBase
         Assert.True(preambleIndex < commentIndex, "Preamble should appear before HTML comment");
     }
 
-    private static int CountOccurrences(string text, string pattern)
-    {
-        int count = 0;
-        int index = 0;
-
-        while (
-            (
-                index = text.IndexOf(
-                    value: pattern,
-                    startIndex: index,
-                    comparisonType: StringComparison.Ordinal
-                )
-            ) >= 0
-        )
-        {
-            count++;
-            index += pattern.Length;
-        }
-
-        return count;
-    }
+    [GeneratedRegex(
+        pattern: @"The format is based on \[Keep a Changelog\]\(https://keepachangelog\.com/en/1\.1\.0/\),",
+        options: RegexOptions.None,
+        matchTimeoutMilliseconds: 1000
+    )]
+    private static partial Regex PreambleFormatLineRegex();
 }

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterPreambleTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterPreambleTests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Credfeto.ChangeLog.Models;
 using Credfeto.ChangeLog.Services;
 using FunFair.Test.Common;
@@ -7,21 +7,6 @@ using Xunit;
 
 namespace Credfeto.ChangeLog.Tests;
 
-[SuppressMessage(
-    category: "Meziantou.Analyzer",
-    checkId: "MA0045:Use async overload",
-    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
-)]
-[SuppressMessage(
-    category: "Microsoft.VisualStudio.Threading.Analyzers",
-    checkId: "VSTHRD002",
-    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
-)]
-[SuppressMessage(
-    category: "Microsoft.Reliability",
-    checkId: "CA2012:UseValueTasksCorrectly",
-    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
-)]
 public sealed class ChangeLogUpdaterPreambleTests : TestBase
 {
     private static readonly ChangeLogLanguage Language = new ChangeLogLanguageFactory().Get(
@@ -51,16 +36,16 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
 -->
 ## [0.0.0] - Project created";
 
-    private static ChangeLogDocument Parse(string content)
+    private static ValueTask<ChangeLogDocument> ParseAsync(string content)
     {
         ChangeLogParser parser = new();
-        return parser.ParseAsync(content, default).GetAwaiter().GetResult();
+        return parser.ParseAsync(content, default);
     }
 
-    private static string Serialise(ChangeLogDocument document)
+    private static ValueTask<string> SerialiseAsync(ChangeLogDocument document)
     {
         ChangeLogSerialiser serialiser = new();
-        return serialiser.SerialiseAsync(document, default).GetAwaiter().GetResult();
+        return serialiser.SerialiseAsync(document, default);
     }
 
     private static void AssertContainsPreamble(string result)
@@ -78,11 +63,15 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
     }
 
     [Fact]
-    public void AddEntry_WithMissingPreamble_PreambleIsAdded()
+    public async Task AddEntry_WithMissingPreamble_PreambleIsAdded()
     {
-        string result = Serialise(
+        string result = await SerialiseAsync(
             ChangeLogFixer.EnsurePreamble(
-                ChangeLogUpdater.AddEntry(Parse(ChangeLogWithoutPreamble), "Added", "Another entry")
+                ChangeLogUpdater.AddEntry(
+                    await ParseAsync(ChangeLogWithoutPreamble),
+                    "Added",
+                    "Another entry"
+                )
             )
         );
 
@@ -90,12 +79,12 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
     }
 
     [Fact]
-    public void RemoveEntry_WithMissingPreamble_PreambleIsAdded()
+    public async Task RemoveEntry_WithMissingPreamble_PreambleIsAdded()
     {
-        string result = Serialise(
+        string result = await SerialiseAsync(
             ChangeLogFixer.EnsurePreamble(
                 ChangeLogUpdater.RemoveEntry(
-                    Parse(ChangeLogWithoutPreamble),
+                    await ParseAsync(ChangeLogWithoutPreamble),
                     "Added",
                     "Existing entry"
                 )
@@ -106,12 +95,12 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
     }
 
     [Fact]
-    public void CreateRelease_WithMissingPreamble_PreambleIsAdded()
+    public async Task CreateRelease_WithMissingPreamble_PreambleIsAdded()
     {
-        string result = Serialise(
+        string result = await SerialiseAsync(
             ChangeLogFixer.EnsurePreamble(
                 ChangeLogUpdater.CreateRelease(
-                    Parse(ChangeLogWithoutPreamble),
+                    await ParseAsync(ChangeLogWithoutPreamble),
                     "1.0.0",
                     pending: true,
                     Language
@@ -123,11 +112,14 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
     }
 
     [Fact]
-    public void EnsureUnreleasedSections_WithMissingPreamble_PreambleIsAdded()
+    public async Task EnsureUnreleasedSections_WithMissingPreamble_PreambleIsAdded()
     {
-        string result = Serialise(
+        string result = await SerialiseAsync(
             ChangeLogFixer.EnsurePreamble(
-                ChangeLogUpdater.EnsureUnreleasedSections(Parse(ChangeLogWithoutPreamble), Language)
+                ChangeLogUpdater.EnsureUnreleasedSections(
+                    await ParseAsync(ChangeLogWithoutPreamble),
+                    Language
+                )
             )
         );
 

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterPreambleTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterPreambleTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Credfeto.ChangeLog.Models;
+using Credfeto.ChangeLog.Services;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.ChangeLog.Tests;
+
+[SuppressMessage(
+    category: "Meziantou.Analyzer",
+    checkId: "MA0045:Use async overload",
+    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
+)]
+[SuppressMessage(
+    category: "Microsoft.VisualStudio.Threading.Analyzers",
+    checkId: "VSTHRD002",
+    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
+)]
+[SuppressMessage(
+    category: "Microsoft.Reliability",
+    checkId: "CA2012:UseValueTasksCorrectly",
+    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
+)]
+public sealed class ChangeLogUpdaterPreambleTests : TestBase
+{
+    private static readonly ChangeLogLanguage Language = new ChangeLogLanguageFactory().Get(
+        ChangeLogLanguageFactory.English
+    );
+
+    private const string ChangeLogWithoutPreamble =
+        @"# Changelog
+All notable changes to this project will be documented in this file.
+
+<!--
+Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
+-->
+
+## [Unreleased]
+### Security
+### Added
+- Existing entry
+### Fixed
+### Changed
+### Deprecated
+### Removed
+### Deployment Changes
+
+<!--
+Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
+-->
+## [0.0.0] - Project created";
+
+    private static ChangeLogDocument Parse(string content)
+    {
+        ChangeLogParser parser = new();
+        return parser.ParseAsync(content, default).GetAwaiter().GetResult();
+    }
+
+    private static string Serialise(ChangeLogDocument document)
+    {
+        ChangeLogSerialiser serialiser = new();
+        return serialiser.SerialiseAsync(document, default).GetAwaiter().GetResult();
+    }
+
+    private static void AssertContainsPreamble(string result)
+    {
+        Assert.Contains(
+            "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),",
+            result,
+            StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).",
+            result,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void AddEntry_WithMissingPreamble_PreambleIsAdded()
+    {
+        string result = Serialise(
+            ChangeLogFixer.EnsurePreamble(
+                ChangeLogUpdater.AddEntry(Parse(ChangeLogWithoutPreamble), "Added", "Another entry")
+            )
+        );
+
+        AssertContainsPreamble(result);
+    }
+
+    [Fact]
+    public void RemoveEntry_WithMissingPreamble_PreambleIsAdded()
+    {
+        string result = Serialise(
+            ChangeLogFixer.EnsurePreamble(
+                ChangeLogUpdater.RemoveEntry(
+                    Parse(ChangeLogWithoutPreamble),
+                    "Added",
+                    "Existing entry"
+                )
+            )
+        );
+
+        AssertContainsPreamble(result);
+    }
+
+    [Fact]
+    public void CreateRelease_WithMissingPreamble_PreambleIsAdded()
+    {
+        string result = Serialise(
+            ChangeLogFixer.EnsurePreamble(
+                ChangeLogUpdater.CreateRelease(
+                    Parse(ChangeLogWithoutPreamble),
+                    "1.0.0",
+                    pending: true,
+                    Language
+                )
+            )
+        );
+
+        AssertContainsPreamble(result);
+    }
+
+    [Fact]
+    public void EnsureUnreleasedSections_WithMissingPreamble_PreambleIsAdded()
+    {
+        string result = Serialise(
+            ChangeLogFixer.EnsurePreamble(
+                ChangeLogUpdater.EnsureUnreleasedSections(Parse(ChangeLogWithoutPreamble), Language)
+            )
+        );
+
+        AssertContainsPreamble(result);
+    }
+}

--- a/src/Credfeto.ChangeLog/Constants/TemplateFile.cs
+++ b/src/Credfeto.ChangeLog/Constants/TemplateFile.cs
@@ -5,6 +5,12 @@ internal static class TemplateFile
     private const string KEEP_A_CHANGELOG = "https://keepachangelog.com/en/1.1.0/";
     private const string SEMANTIC_VERSIONING = "https://semver.org/spec/v2.0.0.html";
 
+    public const string PreambleLine1 =
+        "The format is based on [Keep a Changelog](" + KEEP_A_CHANGELOG + "),";
+
+    public const string PreambleLine2 =
+        "and this project adheres to [Semantic Versioning](" + SEMANTIC_VERSIONING + ").";
+
     public const string Initial =
         @"# Changelog
 All notable changes to this project will be documented in this file.

--- a/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
@@ -51,7 +51,7 @@ internal sealed class ChangeLogFixer : IChangeLogFixer
         return RemoveBlankLinesAfterHeadings(withPreamble);
     }
 
-    private static ChangeLogDocument EnsurePreamble(ChangeLogDocument document)
+    internal static ChangeLogDocument EnsurePreamble(ChangeLogDocument document)
     {
         if (HasPreamble(document.HeaderLines))
         {

--- a/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Credfeto.ChangeLog.Constants;
 using Credfeto.ChangeLog.Models;
+using ZLinq;
 
 namespace Credfeto.ChangeLog.Services;
 
@@ -44,7 +47,75 @@ internal sealed class ChangeLogFixer : IChangeLogFixer
             document: document,
             language: language
         );
-        return RemoveBlankLinesAfterHeadings(ensured);
+        ChangeLogDocument withPreamble = EnsurePreamble(ensured);
+        return RemoveBlankLinesAfterHeadings(withPreamble);
+    }
+
+    private static ChangeLogDocument EnsurePreamble(ChangeLogDocument document)
+    {
+        if (HasPreamble(document.HeaderLines))
+        {
+            return document;
+        }
+
+        return document with
+        {
+            HeaderLines = InsertPreamble(document.HeaderLines),
+        };
+    }
+
+    private static bool HasPreamble(in ImmutableArray<string> headerLines) =>
+        headerLines
+            .AsValueEnumerable()
+            .Any(line =>
+                line.Contains(
+                    value: TemplateFile.PreambleLine1,
+                    comparisonType: System.StringComparison.Ordinal
+                )
+            );
+
+    private static ImmutableArray<string> InsertPreamble(in ImmutableArray<string> headerLines)
+    {
+        int commentStart = FindHtmlCommentStart(headerLines);
+
+        ImmutableArray<string> before =
+            commentStart >= 0 ? headerLines[..commentStart] : headerLines;
+        ImmutableArray<string> after = commentStart >= 0 ? headerLines[commentStart..] : [];
+
+        List<string> result = TrimTrailingBlanks([.. before]);
+        result.Add(string.Empty);
+        result.Add(TemplateFile.PreambleLine1);
+        result.Add(TemplateFile.PreambleLine2);
+        result.Add(string.Empty);
+        result.AddRange(after);
+
+        return [.. result];
+    }
+
+    private static int FindHtmlCommentStart(in ImmutableArray<string> headerLines)
+    {
+        for (int i = 0; i < headerLines.Length; i++)
+        {
+            if (
+                headerLines[i]
+                    .StartsWith(value: "<!--", comparisonType: System.StringComparison.Ordinal)
+            )
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static List<string> TrimTrailingBlanks(List<string> lines)
+    {
+        while (lines.Count > 0 && string.IsNullOrWhiteSpace(lines[^1]))
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return lines;
     }
 
     private static ChangeLogDocument RemoveBlankLinesAfterHeadings(ChangeLogDocument document)

--- a/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -82,14 +81,17 @@ internal sealed class ChangeLogFixer : IChangeLogFixer
             commentStart >= 0 ? headerLines[..commentStart] : headerLines;
         ImmutableArray<string> after = commentStart >= 0 ? headerLines[commentStart..] : [];
 
-        List<string> result = TrimTrailingBlanks([.. before]);
-        result.Add(string.Empty);
-        result.Add(TemplateFile.PreambleLine1);
-        result.Add(TemplateFile.PreambleLine2);
-        result.Add(string.Empty);
-        result.AddRange(after);
+        ImmutableArray<string> trimmed = TrimTrailingBlanks(before);
 
-        return [.. result];
+        return
+        [
+            .. trimmed,
+            string.Empty,
+            TemplateFile.PreambleLine1,
+            TemplateFile.PreambleLine2,
+            string.Empty,
+            .. after,
+        ];
     }
 
     private static int FindHtmlCommentStart(in ImmutableArray<string> headerLines)
@@ -108,14 +110,16 @@ internal sealed class ChangeLogFixer : IChangeLogFixer
         return -1;
     }
 
-    private static List<string> TrimTrailingBlanks(List<string> lines)
+    private static ImmutableArray<string> TrimTrailingBlanks(in ImmutableArray<string> lines)
     {
-        while (lines.Count > 0 && string.IsNullOrWhiteSpace(lines[^1]))
+        int end = lines.Length;
+
+        while (end > 0 && string.IsNullOrWhiteSpace(lines[end - 1]))
         {
-            lines.RemoveAt(lines.Count - 1);
+            end--;
         }
 
-        return lines;
+        return end == lines.Length ? lines : lines[..end];
     }
 
     private static ChangeLogDocument RemoveBlankLinesAfterHeadings(ChangeLogDocument document)

--- a/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
@@ -55,9 +55,10 @@ internal sealed class ChangeLogUpdater : IChangeLogUpdater
             cancellationToken: cancellationToken
         );
         ChangeLogDocument updated = AddEntry(document: document, type: type, message: message);
+        ChangeLogDocument withPreamble = ChangeLogFixer.EnsurePreamble(updated);
         await this._storage.SaveAsync(
             changeLogFileName,
-            document: updated,
+            document: withPreamble,
             cancellationToken: cancellationToken
         );
     }
@@ -76,9 +77,10 @@ internal sealed class ChangeLogUpdater : IChangeLogUpdater
             cancellationToken: cancellationToken
         );
         ChangeLogDocument updated = RemoveEntry(document: document, type: type, message: message);
+        ChangeLogDocument withPreamble = ChangeLogFixer.EnsurePreamble(updated);
         await this._storage.SaveAsync(
             changeLogFileName,
-            document: updated,
+            document: withPreamble,
             cancellationToken: cancellationToken
         );
     }
@@ -101,9 +103,10 @@ internal sealed class ChangeLogUpdater : IChangeLogUpdater
             pending: pending,
             language: language
         );
+        ChangeLogDocument withPreamble = ChangeLogFixer.EnsurePreamble(updated);
         await this._storage.SaveAsync(
             changeLogFileName,
-            document: updated,
+            document: withPreamble,
             cancellationToken: cancellationToken
         );
     }
@@ -123,9 +126,10 @@ internal sealed class ChangeLogUpdater : IChangeLogUpdater
             document: document,
             language: language
         );
+        ChangeLogDocument withPreamble = ChangeLogFixer.EnsurePreamble(updated);
         await this._storage.SaveAsync(
             changeLogFileName,
-            document: updated,
+            document: withPreamble,
             cancellationToken: cancellationToken
         );
     }


### PR DESCRIPTION
## Summary

- Adds `PreambleLine1` and `PreambleLine2` constants to `TemplateFile` for the Keep a Changelog and Semantic Versioning URLs
- `ChangeLogFixer.Fix()` now calls a new `EnsurePreamble()` step that inserts the standard preamble into `HeaderLines` when it is missing
- Preamble is inserted before any existing HTML comment (e.g. `<!--`) if present, or appended after the title block
- Adds 4 new tests covering: missing preamble added, existing preamble not duplicated, preamble inserted before HTML comment

Closes #249