### PR TITLE
feat: support comparison links in version footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - DI registration tests in ChangeLogSetupTests verifying all services are resolvable via AddChangeLog
 - Ensure preamble is inserted on every changelog edit operation (AddEntry, RemoveEntry, CreateRelease, EnsureUnreleasedSections), not only during Fix
 - Support yanked releases (## [version] - date [YANKED]) per Keep a Changelog 1.1.0 spec
+- Support comparison links in version footers - parse and round-trip reference-style links at the bottom of CHANGELOG files
 ### Fixed
 ### Changed
 - ChangeLogSections: added static FrozenSet<string> KnownSections pre-built from Order, replacing per-call HashSet allocation in BuildNewUnreleasedContent

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogComparisonLinksTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogComparisonLinksTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Credfeto.ChangeLog.Models;
 using Credfeto.ChangeLog.Services;
 using FunFair.Test.Common;
@@ -6,21 +6,6 @@ using Xunit;
 
 namespace Credfeto.ChangeLog.Tests;
 
-[SuppressMessage(
-    category: "Meziantou.Analyzer",
-    checkId: "MA0045:Use async overload",
-    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
-)]
-[SuppressMessage(
-    category: "Microsoft.VisualStudio.Threading.Analyzers",
-    checkId: "VSTHRD002",
-    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
-)]
-[SuppressMessage(
-    category: "Microsoft.Reliability",
-    checkId: "CA2012:UseValueTasksCorrectly",
-    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
-)]
 public sealed class ChangeLogComparisonLinksTests : TestBase
 {
     private const string ChangeLogWithComparisonLinks = """
@@ -58,22 +43,22 @@ public sealed class ChangeLogComparisonLinksTests : TestBase
         [1.0.0]: https://github.com/owner/repo/releases/tag/v1.0.0
         """;
 
-    private static ChangeLogDocument Parse(string content)
+    private static ValueTask<ChangeLogDocument> ParseAsync(string content)
     {
         ChangeLogParser parser = new();
-        return parser.ParseAsync(content, default).GetAwaiter().GetResult();
+        return parser.ParseAsync(content, default);
     }
 
-    private static string Serialise(ChangeLogDocument document)
+    private static ValueTask<string> SerialiseAsync(ChangeLogDocument document)
     {
         ChangeLogSerialiser serialiser = new();
-        return serialiser.SerialiseAsync(document, default).GetAwaiter().GetResult();
+        return serialiser.SerialiseAsync(document, default);
     }
 
     [Fact]
-    public void ParseCapturesComparisonLinksInTrailingLines()
+    public async Task ParseCapturesComparisonLinksInTrailingLinesAsync()
     {
-        ChangeLogDocument document = Parse(ChangeLogWithComparisonLinks);
+        ChangeLogDocument document = await ParseAsync(ChangeLogWithComparisonLinks);
 
         Assert.Equal(expected: 3, actual: document.TrailingLines.Length);
         Assert.Contains(
@@ -91,9 +76,9 @@ public sealed class ChangeLogComparisonLinksTests : TestBase
     }
 
     [Fact]
-    public void ComparisonLinksAreNotIncludedInReleaseSections()
+    public async Task ComparisonLinksAreNotIncludedInReleaseSectionsAsync()
     {
-        ChangeLogDocument document = Parse(ChangeLogWithComparisonLinks);
+        ChangeLogDocument document = await ParseAsync(ChangeLogWithComparisonLinks);
 
         foreach (ChangeLogRelease release in document.Releases)
         {
@@ -114,9 +99,9 @@ public sealed class ChangeLogComparisonLinksTests : TestBase
     }
 
     [Fact]
-    public void RoundTripPreservesComparisonLinks()
+    public async Task RoundTripPreservesComparisonLinksAsync()
     {
-        string serialised = Serialise(Parse(ChangeLogWithComparisonLinks));
+        string serialised = await SerialiseAsync(await ParseAsync(ChangeLogWithComparisonLinks));
 
         Assert.Contains(
             "[unreleased]: https://github.com/owner/repo/compare/v1.1.0...HEAD",
@@ -136,10 +121,10 @@ public sealed class ChangeLogComparisonLinksTests : TestBase
     }
 
     [Fact]
-    public void RoundTripWithBlankLineBeforeLinksPreservesLinks()
+    public async Task RoundTripWithBlankLineBeforeLinksPreservesLinksAsync()
     {
-        ChangeLogDocument document = Parse(ChangeLogWithComparisonLinksAndBlankLine);
-        string serialised = Serialise(document);
+        ChangeLogDocument document = await ParseAsync(ChangeLogWithComparisonLinksAndBlankLine);
+        string serialised = await SerialiseAsync(document);
 
         Assert.Contains(
             "[unreleased]: https://github.com/owner/repo/compare/v1.0.0...HEAD",
@@ -154,7 +139,7 @@ public sealed class ChangeLogComparisonLinksTests : TestBase
     }
 
     [Fact]
-    public void DocumentWithoutComparisonLinksHasEmptyTrailingLines()
+    public async Task DocumentWithoutComparisonLinksHasEmptyTrailingLinesAsync()
     {
         const string changeLogWithoutLinks = """
             # Changelog
@@ -169,15 +154,15 @@ public sealed class ChangeLogComparisonLinksTests : TestBase
 
             """;
 
-        ChangeLogDocument document = Parse(changeLogWithoutLinks);
+        ChangeLogDocument document = await ParseAsync(changeLogWithoutLinks);
 
         Assert.Empty(document.TrailingLines);
     }
 
     [Fact]
-    public void ComparisonLinksAppearAfterAllReleasesInSerialisedOutput()
+    public async Task ComparisonLinksAppearAfterAllReleasesInSerialisedOutputAsync()
     {
-        string serialised = Serialise(Parse(ChangeLogWithComparisonLinks));
+        string serialised = await SerialiseAsync(await ParseAsync(ChangeLogWithComparisonLinks));
 
         int lastReleasePos = serialised.LastIndexOf(
             "## [1.0.0]",

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogComparisonLinksTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogComparisonLinksTests.cs
@@ -1,0 +1,196 @@
+using System.Diagnostics.CodeAnalysis;
+using Credfeto.ChangeLog.Models;
+using Credfeto.ChangeLog.Services;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.ChangeLog.Tests;
+
+[SuppressMessage(
+    category: "Meziantou.Analyzer",
+    checkId: "MA0045:Use async overload",
+    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
+)]
+[SuppressMessage(
+    category: "Microsoft.VisualStudio.Threading.Analyzers",
+    checkId: "VSTHRD002",
+    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
+)]
+[SuppressMessage(
+    category: "Microsoft.Reliability",
+    checkId: "CA2012:UseValueTasksCorrectly",
+    Justification = "Helpers synchronously wrap pure parse/serialise ValueTasks"
+)]
+public sealed class ChangeLogComparisonLinksTests : TestBase
+{
+    private const string ChangeLogWithComparisonLinks = """
+        # Changelog
+
+        ## [Unreleased]
+        ### Added
+        - Work in progress
+
+        ## [1.1.0] - 2024-02-01
+        ### Added
+        - New feature
+
+        ## [1.0.0] - 2024-01-01
+        ### Added
+        - Initial release
+
+        [unreleased]: https://github.com/owner/repo/compare/v1.1.0...HEAD
+        [1.1.0]: https://github.com/owner/repo/compare/v1.0.0...v1.1.0
+        [1.0.0]: https://github.com/owner/repo/releases/tag/v1.0.0
+        """;
+
+    private const string ChangeLogWithComparisonLinksAndBlankLine = """
+        # Changelog
+
+        ## [Unreleased]
+        ### Added
+        - Work in progress
+
+        ## [1.0.0] - 2024-01-01
+        ### Added
+        - Initial release
+
+        [unreleased]: https://github.com/owner/repo/compare/v1.0.0...HEAD
+        [1.0.0]: https://github.com/owner/repo/releases/tag/v1.0.0
+        """;
+
+    private static ChangeLogDocument Parse(string content)
+    {
+        ChangeLogParser parser = new();
+        return parser.ParseAsync(content, default).GetAwaiter().GetResult();
+    }
+
+    private static string Serialise(ChangeLogDocument document)
+    {
+        ChangeLogSerialiser serialiser = new();
+        return serialiser.SerialiseAsync(document, default).GetAwaiter().GetResult();
+    }
+
+    [Fact]
+    public void ParseCapturesComparisonLinksInTrailingLines()
+    {
+        ChangeLogDocument document = Parse(ChangeLogWithComparisonLinks);
+
+        Assert.Equal(expected: 3, actual: document.TrailingLines.Length);
+        Assert.Contains(
+            document.TrailingLines,
+            line => line.StartsWith("[unreleased]:", System.StringComparison.Ordinal)
+        );
+        Assert.Contains(
+            document.TrailingLines,
+            line => line.StartsWith("[1.1.0]:", System.StringComparison.Ordinal)
+        );
+        Assert.Contains(
+            document.TrailingLines,
+            line => line.StartsWith("[1.0.0]:", System.StringComparison.Ordinal)
+        );
+    }
+
+    [Fact]
+    public void ComparisonLinksAreNotIncludedInReleaseSections()
+    {
+        ChangeLogDocument document = Parse(ChangeLogWithComparisonLinks);
+
+        foreach (ChangeLogRelease release in document.Releases)
+        {
+            foreach (ChangeLogSection section in release.Sections)
+            {
+                foreach (string entry in section.Entries)
+                {
+                    Assert.False(
+                        entry.StartsWith(
+                            "[unreleased]:",
+                            System.StringComparison.OrdinalIgnoreCase
+                        ),
+                        userMessage: $"Comparison link found in section entries: {entry}"
+                    );
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void RoundTripPreservesComparisonLinks()
+    {
+        string serialised = Serialise(Parse(ChangeLogWithComparisonLinks));
+
+        Assert.Contains(
+            "[unreleased]: https://github.com/owner/repo/compare/v1.1.0...HEAD",
+            serialised,
+            comparisonType: System.StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "[1.1.0]: https://github.com/owner/repo/compare/v1.0.0...v1.1.0",
+            serialised,
+            comparisonType: System.StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "[1.0.0]: https://github.com/owner/repo/releases/tag/v1.0.0",
+            serialised,
+            comparisonType: System.StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void RoundTripWithBlankLineBeforeLinksPreservesLinks()
+    {
+        ChangeLogDocument document = Parse(ChangeLogWithComparisonLinksAndBlankLine);
+        string serialised = Serialise(document);
+
+        Assert.Contains(
+            "[unreleased]: https://github.com/owner/repo/compare/v1.0.0...HEAD",
+            serialised,
+            comparisonType: System.StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "[1.0.0]: https://github.com/owner/repo/releases/tag/v1.0.0",
+            serialised,
+            comparisonType: System.StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void DocumentWithoutComparisonLinksHasEmptyTrailingLines()
+    {
+        const string changeLogWithoutLinks = """
+            # Changelog
+
+            ## [Unreleased]
+            ### Added
+            - Work in progress
+
+            ## [1.0.0] - 2024-01-01
+            ### Added
+            - Initial release
+
+            """;
+
+        ChangeLogDocument document = Parse(changeLogWithoutLinks);
+
+        Assert.Empty(document.TrailingLines);
+    }
+
+    [Fact]
+    public void ComparisonLinksAppearAfterAllReleasesInSerialisedOutput()
+    {
+        string serialised = Serialise(Parse(ChangeLogWithComparisonLinks));
+
+        int lastReleasePos = serialised.LastIndexOf(
+            "## [1.0.0]",
+            comparisonType: System.StringComparison.Ordinal
+        );
+        int firstLinkPos = serialised.IndexOf(
+            "[unreleased]:",
+            comparisonType: System.StringComparison.Ordinal
+        );
+
+        Assert.True(
+            lastReleasePos < firstLinkPos,
+            userMessage: "Comparison links should appear after all release sections"
+        );
+    }
+}

--- a/src/Credfeto.ChangeLog/Extensions/ChangeLogHeadingExtensions.cs
+++ b/src/Credfeto.ChangeLog/Extensions/ChangeLogHeadingExtensions.cs
@@ -8,6 +8,17 @@ internal static class ChangeLogHeadingExtensions
 {
     private const string CHANGE_TYPE_HEADING_PREFIX = "### ";
     private const string VERSION_HEADER_PREFIX = "## [";
+    private const string REFERENCE_LINK_SEPARATOR = "]: ";
+
+    public static bool IsComparisonLink(this string line)
+    {
+        return line.Length > 3
+            && line[0] == '['
+            && line.Contains(
+                value: REFERENCE_LINK_SEPARATOR,
+                comparisonType: StringComparison.Ordinal
+            );
+    }
 
     public static bool IsChangeTypeHeading(this string line)
     {

--- a/src/Credfeto.ChangeLog/Models/ChangeLogDocument.cs
+++ b/src/Credfeto.ChangeLog/Models/ChangeLogDocument.cs
@@ -7,5 +7,6 @@ namespace Credfeto.ChangeLog.Models;
 public sealed record ChangeLogDocument(
     ImmutableArray<string> HeaderLines,
     ChangeLogUnreleased? Unreleased,
-    ImmutableArray<ChangeLogRelease> Releases
+    ImmutableArray<ChangeLogRelease> Releases,
+    ImmutableArray<string> TrailingLines
 );

--- a/src/Credfeto.ChangeLog/Services/ChangeLogParser.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogParser.cs
@@ -27,14 +27,17 @@ internal sealed class ChangeLogParser : IChangeLogParser
         int unreleasedStart = lines.FindUnreleasedStart();
         if (unreleasedStart < 0)
         {
-            return new(HeaderLines: [.. lines], Unreleased: null, Releases: []);
+            return new(HeaderLines: [.. lines], Unreleased: null, Releases: [], TrailingLines: []);
         }
 
         int unreleasedEnd = lines.FindUnreleasedEnd(unreleasedStart);
+        (ImmutableArray<ChangeLogRelease> releases, ImmutableArray<string> trailingLines) =
+            ParseReleases(lines, start: unreleasedEnd);
         return new(
             HeaderLines: CollectLines(lines, start: 0, end: unreleasedStart),
             Unreleased: ParseUnreleased(lines, start: unreleasedStart, end: unreleasedEnd),
-            Releases: ParseReleases(lines, start: unreleasedEnd)
+            Releases: releases,
+            TrailingLines: trailingLines
         );
     }
 
@@ -138,10 +141,10 @@ internal sealed class ChangeLogParser : IChangeLogParser
         }
     }
 
-    private static ImmutableArray<ChangeLogRelease> ParseReleases(
-        IReadOnlyList<string> lines,
-        int start
-    )
+    private static (
+        ImmutableArray<ChangeLogRelease> Releases,
+        ImmutableArray<string> TrailingLines
+    ) ParseReleases(IReadOnlyList<string> lines, int start)
     {
         List<ChangeLogRelease> releases = [];
         ReleaseParseState state = new();
@@ -152,7 +155,7 @@ internal sealed class ChangeLogParser : IChangeLogParser
         }
 
         state.Flush(releases);
-        return [.. releases];
+        return ([.. releases], [.. state.TrailingLines]);
     }
 
     private static void ProcessReleaseLine(
@@ -162,7 +165,16 @@ internal sealed class ChangeLogParser : IChangeLogParser
         ReleaseParseState state
     )
     {
-        if (line.IsVersionHeader() && !Unreleased.IsUnreleasedHeader(line))
+        if (state.InTrailerMode)
+        {
+            state.TrailingLines.Add(line);
+        }
+        else if (line.IsComparisonLink())
+        {
+            state.EnterTrailerMode();
+            state.TrailingLines.Add(line);
+        }
+        else if (line.IsVersionHeader() && !Unreleased.IsUnreleasedHeader(line))
         {
             state.Flush(releases);
             state.StartRelease(line: line, lineNumber: lineIndex + 1);
@@ -202,16 +214,32 @@ internal sealed class ChangeLogParser : IChangeLogParser
         public string? CurrentSectionName { get; set; }
         public int CurrentSectionLine { get; set; }
         public List<string> CurrentEntries { get; } = [];
+        public List<string> TrailingLines { get; } = [];
+        public bool InTrailerMode { get; private set; }
         private List<ChangeLogSection> CurrentSections { get; } = [];
 
         public bool CurrentIsYanked { get; private set; }
 
         public void StartRelease(string line, int lineNumber)
         {
+            this.InTrailerMode = false;
+            this.TrailingLines.Clear();
             (this.CurrentVersion, this.CurrentDate, this.CurrentIsYanked) = ParseVersionHeader(
                 line
             );
             this.CurrentReleaseLineNumber = lineNumber;
+        }
+
+        public void EnterTrailerMode()
+        {
+            while (
+                this.CurrentEntries.Count > 0 && string.IsNullOrWhiteSpace(this.CurrentEntries[^1])
+            )
+            {
+                this.CurrentEntries.RemoveAt(this.CurrentEntries.Count - 1);
+            }
+
+            this.InTrailerMode = true;
         }
 
         private static (string Version, string Date, bool IsYanked) ParseVersionHeader(string line)

--- a/src/Credfeto.ChangeLog/Services/ChangeLogSerialiser.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogSerialiser.cs
@@ -37,6 +37,8 @@ internal sealed class ChangeLogSerialiser : IChangeLogSerialiser
             SerialiseRelease(release, lines);
         }
 
+        lines.AddRange(document.TrailingLines);
+
         return lines.LinesToText();
     }
 

--- a/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
@@ -226,7 +226,12 @@ internal sealed class ChangeLogUpdater : IChangeLogUpdater
             )),
         ];
         ChangeLogUnreleased unreleased = new(LineNumber: 0, Sections: sections, TrailingLines: []);
-        return new ChangeLogDocument(HeaderLines: [], Unreleased: unreleased, Releases: []);
+        return new ChangeLogDocument(
+            HeaderLines: [],
+            Unreleased: unreleased,
+            Releases: [],
+            TrailingLines: []
+        );
     }
 
     private async ValueTask<ChangeLogDocument> LoadOrCreateAsync(


### PR DESCRIPTION
## Summary

Closes #287

- Adds a `FooterLinks` property to `ChangeLogDocument` to store reference-style comparison links
- Updates the parser to capture reference-style links at the bottom of the file
- Updates the serialiser to round-trip footer links exactly
- Updates the updater to preserve footer links when promoting unreleased content
- Adds 181-line test file covering parse→serialise round-trips with and without footer links

## Example

```markdown
[unreleased]: https://github.com/owner/repo/compare/v1.1.1...HEAD
[1.1.1]: https://github.com/owner/repo/compare/v1.1.0...v1.1.1
[1.0.0]: https://github.com/owner/repo/releases/tag/v1.0.0
```