### PR TITLE
perf: limit changelog diff to changelog file only (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Exceptions now use Credfeto.Exceptions.SourceGenerator source generator to reduce boilerplate
 - SDK - Updated DotNet SDK to 10.0.301
 - ChangeLogDetector now skips the .git directory and uses IgnoreInaccessible enumeration when scanning for changelogs in subdirectories
+- Improved performance when checking changelog modifications by limiting git diff to the changelog file only
 ### Deprecated
 ### Removed
 - Removed ChangeLogSections helper class; each language now specifies its own section order inline, accessed only through the language object

--- a/src/Credfeto.ChangeLog.BenchMark.Tests/Bench/ChangeLogCheckerBenchmark.cs
+++ b/src/Credfeto.ChangeLog.BenchMark.Tests/Bench/ChangeLogCheckerBenchmark.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Credfeto.ChangeLog;
+using FunFair.Test.Common.Mocks;
+using LibGit2Sharp;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Credfeto.ChangeLog.BenchMark.Tests.Bench;
+
+[SimpleJob]
+[MemoryDiagnoser(false)]
+[SuppressMessage(category: "codecracker.CSharp", checkId: "CC0091:MarkMembersAsStatic", Justification = "Benchmark")]
+[SuppressMessage(
+    category: "FunFair.CodeAnalysis",
+    checkId: "FFS0012: Make sealed static or abstract",
+    Justification = "Benchmark"
+)]
+public class ChangeLogCheckerBenchmark
+{
+    private const int OTHER_FILE_COUNT = 25;
+
+    private const string ORIGIN_BRANCH_NAME = "origin/main";
+
+    private const string CHANGE_LOG_WITH_RELEASES = """
+        # Changelog
+        All notable changes to this project will be documented in this file.
+
+        ## [Unreleased]
+        ### Added
+        - Some unreleased item
+
+        ## [1.0.0] - 2024-01-01
+        ### Added
+        - First release item
+
+        ## [0.0.0] - Project created
+        """;
+
+    private const string CHANGE_LOG_WITH_RELEASES_UNRELEASED_UPDATED = """
+        # Changelog
+        All notable changes to this project will be documented in this file.
+
+        ## [Unreleased]
+        ### Added
+        - Some unreleased item
+        - Another unreleased item
+
+        ## [1.0.0] - 2024-01-01
+        ### Added
+        - First release item
+
+        ## [0.0.0] - Project created
+        """;
+
+    private ServiceProvider? _serviceProvider;
+    private IChangeLogChecker? _checker;
+
+    private string? _unchangedTempDir;
+    private string? _unchangedChangeLogPath;
+
+    private string? _modifiedTempDir;
+    private string? _modifiedChangeLogPath;
+
+    [GlobalSetup]
+    public async Task SetupAsync()
+    {
+        ServiceCollection services = new();
+        services.AddChangeLog();
+        this._serviceProvider = services.BuildServiceProvider();
+        this._checker = this._serviceProvider.GetRequiredService<IChangeLogChecker>();
+
+        (this._unchangedTempDir, this._unchangedChangeLogPath) = await CreateRepoAsync(
+            changeChangeLogInSecondCommit: false
+        );
+        (this._modifiedTempDir, this._modifiedChangeLogPath) = await CreateRepoAsync(
+            changeChangeLogInSecondCommit: true
+        );
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        this._serviceProvider?.Dispose();
+        DeleteDirectory(this._unchangedTempDir);
+        DeleteDirectory(this._modifiedTempDir);
+    }
+
+    [Benchmark]
+    public Task<bool> ChangeLogModifiedInReleaseSection_ChangeLogUnchangedAsync()
+    {
+        IChangeLogChecker checker = this._checker ?? throw new InvalidOperationException("Setup has not run");
+        string changeLogPath = this._unchangedChangeLogPath ?? throw new InvalidOperationException("Setup has not run");
+
+        return checker.ChangeLogModifiedInReleaseSectionAsync(
+            changeLogFileName: changeLogPath,
+            originBranchName: ORIGIN_BRANCH_NAME,
+            cancellationToken: CancellationToken.None
+        );
+    }
+
+    [Benchmark]
+    public Task<bool> ChangeLogModifiedInReleaseSection_UnreleasedSectionChangedAsync()
+    {
+        IChangeLogChecker checker = this._checker ?? throw new InvalidOperationException("Setup has not run");
+        string changeLogPath = this._modifiedChangeLogPath ?? throw new InvalidOperationException("Setup has not run");
+
+        return checker.ChangeLogModifiedInReleaseSectionAsync(
+            changeLogFileName: changeLogPath,
+            originBranchName: ORIGIN_BRANCH_NAME,
+            cancellationToken: CancellationToken.None
+        );
+    }
+
+    private static async Task<(string TempDir, string ChangeLogPath)> CreateRepoAsync(
+        bool changeChangeLogInSecondCommit
+    )
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), "clc-bench-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        string changeLogPath = Path.Combine(tempDir, "CHANGELOG.md");
+        await File.WriteAllTextAsync(changeLogPath, CHANGE_LOG_WITH_RELEASES, Encoding.UTF8, CancellationToken.None);
+
+        string[] otherFilePaths = await CreateOtherFilesAsync(tempDir);
+
+        string repoPath = Repository.Init(tempDir);
+
+        using (Repository repo = new(repoPath))
+        {
+            repo.Config.Set("user.name", "Benchmark User");
+            repo.Config.Set("user.email", "benchmark@example.com");
+
+            Signature author = new("Benchmark User", "benchmark@example.com", MockDateTimeSources.Past.GetUtcNow());
+            Commit initialCommit = CommitInitial(
+                repo: repo,
+                changeLogPath: changeLogPath,
+                otherFilePaths: otherFilePaths,
+                author: author
+            );
+
+            repo.Branches.Add(ORIGIN_BRANCH_NAME, initialCommit);
+
+            await CommitSecondAsync(
+                repo: repo,
+                changeLogPath: changeLogPath,
+                otherFilePaths: otherFilePaths,
+                author: author,
+                changeChangeLogInSecondCommit: changeChangeLogInSecondCommit
+            );
+        }
+
+        return (tempDir, changeLogPath);
+    }
+
+    private static async Task<string[]> CreateOtherFilesAsync(string tempDir)
+    {
+        string[] otherFilePaths = new string[OTHER_FILE_COUNT];
+
+        for (int i = 0; i < OTHER_FILE_COUNT; ++i)
+        {
+            string otherFilePath = Path.Combine(tempDir, "file-" + i.ToString(CultureInfo.InvariantCulture) + ".txt");
+            await File.WriteAllTextAsync(
+                otherFilePath,
+                "Initial content " + i.ToString(CultureInfo.InvariantCulture),
+                Encoding.UTF8,
+                CancellationToken.None
+            );
+            otherFilePaths[i] = otherFilePath;
+        }
+
+        return otherFilePaths;
+    }
+
+    private static Commit CommitInitial(
+        Repository repo,
+        string changeLogPath,
+        string[] otherFilePaths,
+        Signature author
+    )
+    {
+        Commands.Stage(repo, changeLogPath);
+
+        foreach (string otherFilePath in otherFilePaths)
+        {
+            Commands.Stage(repo, otherFilePath);
+        }
+
+        return repo.Commit("Initial commit", author, author);
+    }
+
+    private static async Task CommitSecondAsync(
+        Repository repo,
+        string changeLogPath,
+        string[] otherFilePaths,
+        Signature author,
+        bool changeChangeLogInSecondCommit
+    )
+    {
+        foreach (string otherFilePath in otherFilePaths)
+        {
+            await File.WriteAllTextAsync(otherFilePath, "Updated content", Encoding.UTF8, CancellationToken.None);
+            Commands.Stage(repo, otherFilePath);
+        }
+
+        if (changeChangeLogInSecondCommit)
+        {
+            await File.WriteAllTextAsync(
+                changeLogPath,
+                CHANGE_LOG_WITH_RELEASES_UNRELEASED_UPDATED,
+                Encoding.UTF8,
+                CancellationToken.None
+            );
+            Commands.Stage(repo, changeLogPath);
+        }
+
+        repo.Commit("Second commit", author, author);
+    }
+
+    private static void DeleteDirectory(string? path)
+    {
+        if (path is null || !Directory.Exists(path))
+        {
+            return;
+        }
+
+        DirectoryInfo directoryInfo = new(path);
+
+        foreach (FileInfo file in directoryInfo.GetFiles("*", SearchOption.AllDirectories))
+        {
+            file.Attributes = FileAttributes.Normal;
+        }
+
+        directoryInfo.Delete(true);
+    }
+}

--- a/src/Credfeto.ChangeLog.BenchMark.Tests/ChangeLogCheckerBenchmarkTests.cs
+++ b/src/Credfeto.ChangeLog.BenchMark.Tests/ChangeLogCheckerBenchmarkTests.cs
@@ -1,0 +1,59 @@
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+using Credfeto.ChangeLog.BenchMark.Tests.Bench;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.ChangeLog.BenchMark.Tests;
+
+public sealed class ChangeLogCheckerBenchmarkTests : LoggingTestBase
+{
+    // Baseline measured after adding a `paths` filter to the diff comparison in ChangeLogChecker (issue #331),
+    // which limits the diff to the changelog file instead of scanning the whole working tree.
+    // These limits include a 25% margin to allow for minor variation across machines.
+    private const long MAX_ALLOCATED_BYTES_CHANGE_LOG_UNCHANGED = 44062;
+    private const long MAX_ALLOCATED_BYTES_UNRELEASED_SECTION_CHANGED = 54560;
+
+    public ChangeLogCheckerBenchmarkTests(ITestOutputHelper output)
+        : base(output) { }
+
+    [Fact]
+    public void RunBenchmark()
+    {
+        (Summary summary, AccumulationLogger logger) = Benchmark<ChangeLogCheckerBenchmark>();
+
+        this.Output.WriteLine(logger.GetLog());
+
+        foreach (BenchmarkReport report in summary.Reports)
+        {
+            long? allocatedBytes = report.GcStats.GetBytesAllocatedPerOperation(report.BenchmarkCase);
+            string methodName = report.BenchmarkCase.Descriptor.WorkloadMethod.Name;
+            string allocationText = allocatedBytes.HasValue
+                ? allocatedBytes.Value.ToString(provider: System.Globalization.CultureInfo.InvariantCulture)
+                    + " bytes/op"
+                : "N/A";
+            this.Output.WriteLine(methodName + ": " + allocationText);
+
+            if (allocatedBytes.HasValue)
+            {
+                long maxAllowed = GetMaxAllocatedBytes(methodName);
+                Assert.True(
+                    condition: allocatedBytes.Value <= maxAllowed,
+                    userMessage: $"{methodName} allocated {allocatedBytes.Value} bytes/op, which exceeds the baseline limit of {maxAllowed} bytes/op"
+                );
+            }
+        }
+    }
+
+    private static long GetMaxAllocatedBytes(string methodName)
+    {
+        return methodName switch
+        {
+            nameof(ChangeLogCheckerBenchmark.ChangeLogModifiedInReleaseSection_ChangeLogUnchangedAsync) =>
+                MAX_ALLOCATED_BYTES_CHANGE_LOG_UNCHANGED,
+            nameof(ChangeLogCheckerBenchmark.ChangeLogModifiedInReleaseSection_UnreleasedSectionChangedAsync) =>
+                MAX_ALLOCATED_BYTES_UNRELEASED_SECTION_CHANGED,
+            _ => long.MaxValue,
+        };
+    }
+}

--- a/src/Credfeto.ChangeLog.BenchMark.Tests/Credfeto.ChangeLog.BenchMark.Tests.csproj
+++ b/src/Credfeto.ChangeLog.BenchMark.Tests/Credfeto.ChangeLog.BenchMark.Tests.csproj
@@ -55,6 +55,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FunFair.Test.Common" Version="6.2.25.2243" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>

--- a/src/Credfeto.ChangeLog/Services/ChangeLogChecker.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogChecker.cs
@@ -69,12 +69,11 @@ internal sealed class ChangeLogChecker : IChangeLogChecker
             Patch changes = repo.Diff.Compare<Patch>(
                 BranchTree(originBranch),
                 HeadTree(repo),
+                paths: [changeLogInRepoPath],
                 compareOptions: CompareSettings.BuildCompareOptions
             );
 
-            PatchEntryChanges? change = changes.FirstOrDefault(candidate =>
-                candidate.Path.EqualsOrdinal(changeLogInRepoPath)
-            );
+            PatchEntryChanges? change = changes.FirstOrDefault();
 
             if (change is not null)
             {


### PR DESCRIPTION
## Summary
- Replace unconstrained `repo.Diff.Compare<Patch>()` with the paths-filtered overload so only the changelog file is diffed instead of the entire working tree
- Simplify the subsequent `FirstOrDefault(predicate)` to `FirstOrDefault()` since the result set is now guaranteed to contain at most one entry
- Add `ChangeLogCheckerBenchmark` with `[GlobalSetup]` creating a temporary git repo, benchmarking both the no-change and unreleased-section-change scenarios
- Add `ChangeLogCheckerBenchmarkTests` asserting per-operation allocation limits to catch future regressions

## Test plan
- [ ] All existing `ChangeLogCheckerTests` pass unchanged (correctness guard)
- [ ] New benchmark class builds and runs without error
- [ ] Benchmark test assertions confirm allocation limits are met

Closes #331