### PR TITLE
fix: CLI silently exits 0 when option combinations are incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Fixed Pull Request workflow failing when pull_request_target jobs used local composite actions without a prior workspace checkout
 - Provide properly translated section names and unreleased section labels for Czech, Danish, German, Spanish, French, Italian, Dutch, Chinese Simplified, and Chinese Traditional — these were incorrectly using English section order
 - ChangeLogDetector no longer reports 'changelog not found' due to access errors in nested directories; checks root CHANGELOG.md first without a full directory scan
+- CLI no longer silently exits 0 when required option combinations are incomplete (--add/--remove without --message, --extract without --version, --version without --extract, or no recognised command) — it now throws InvalidOptionsException and exits with a non-zero code.
 ### Changed
 - ChangeLogSections: added static FrozenSet<string> KnownSections pre-built from Order, replacing per-call HashSet allocation in BuildNewUnreleasedContent
 - Refined changelog section linting and related updater/fixer command behaviour.

--- a/src/Credfeto.ChangeLog.Cmd.Tests/ProgramTests.cs
+++ b/src/Credfeto.ChangeLog.Cmd.Tests/ProgramTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -387,6 +387,76 @@ public sealed class ProgramTests : TestBase
         try
         {
             int result = await Credfeto.ChangeLog.Cmd.Program.Main(["--changelog", tempFile]);
+            Assert.Equal(expected: 1, actual: result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Main_AddWithoutMessage_ReturnsError()
+    {
+        string tempFile = await CreateTempChangeLogAsync(VALID_CHANGELOG);
+
+        try
+        {
+            int result = await Credfeto.ChangeLog.Cmd.Program.Main(["--changelog", tempFile, "--add", "Added"]);
+            Assert.Equal(expected: 1, actual: result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Main_RemoveWithoutMessage_ReturnsError()
+    {
+        string tempFile = await CreateTempChangeLogAsync(VALID_CHANGELOG);
+
+        try
+        {
+            int result = await Credfeto.ChangeLog.Cmd.Program.Main(["--changelog", tempFile, "--remove", "Added"]);
+            Assert.Equal(expected: 1, actual: result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Main_ExtractWithoutVersion_ReturnsError()
+    {
+        string tempFile = await CreateTempChangeLogAsync(CHANGELOG_WITH_RELEASE);
+        string outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+
+        try
+        {
+            int result = await Credfeto.ChangeLog.Cmd.Program.Main(["--changelog", tempFile, "--extract", outputFile]);
+            Assert.Equal(expected: 1, actual: result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+
+            if (File.Exists(outputFile))
+            {
+                File.Delete(outputFile);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Main_VersionWithoutExtract_ReturnsError()
+    {
+        string tempFile = await CreateTempChangeLogAsync(CHANGELOG_WITH_RELEASE);
+
+        try
+        {
+            int result = await Credfeto.ChangeLog.Cmd.Program.Main(["--changelog", tempFile, "--version", "1.0.0"]);
             Assert.Equal(expected: 1, actual: result);
         }
         finally

--- a/src/Credfeto.ChangeLog.Cmd/Program.cs
+++ b/src/Credfeto.ChangeLog.Cmd/Program.cs
@@ -48,8 +48,10 @@ internal static class Program
             .GetRequiredService<IChangeLogLanguageFactory>()
             .Get(ChangeLogLanguageFactory.English);
 
-        if (options.Extract is not null && options.Version is not null)
+        if (options.Extract is not null || options.Version is not null)
         {
+            EnsureExtractOptionsComplete(options);
+
             await ExtractChangeLogTextForVersionAsync(
                 options: options,
                 detector: detector,
@@ -60,8 +62,10 @@ internal static class Program
             return;
         }
 
-        if (options.Add is not null && options.Message is not null)
+        if (options.Add is not null)
         {
+            EnsureMessageProvided(options: options, commandOptionName: "--add");
+
             await AddEntryToUnreleasedChangelogAsync(
                 options: options,
                 detector: detector,
@@ -73,8 +77,10 @@ internal static class Program
             return;
         }
 
-        if (options.Remove is not null && options.Message is not null)
+        if (options.Remove is not null)
         {
+            EnsureMessageProvided(options: options, commandOptionName: "--remove");
+
             await RemoveEntryFromUnreleasedChangelogAsync(
                 options: options,
                 detector: detector,
@@ -93,6 +99,27 @@ internal static class Program
             services: services,
             cancellationToken: cancellationToken
         );
+    }
+
+    private static void EnsureExtractOptionsComplete(Options options)
+    {
+        if (options.Extract is null)
+        {
+            throw new InvalidOptionsException("--version requires --extract");
+        }
+
+        if (options.Version is null)
+        {
+            throw new InvalidOptionsException("--extract requires --version");
+        }
+    }
+
+    private static void EnsureMessageProvided(Options options, string commandOptionName)
+    {
+        if (options.Message is null)
+        {
+            throw new InvalidOptionsException($"{commandOptionName} requires --message");
+        }
     }
 
     private static async Task ParsedOkContinuationAsync(
@@ -150,7 +177,11 @@ internal static class Program
                 fixer: services.GetRequiredService<IChangeLogFixer>(),
                 cancellationToken: cancellationToken
             );
+
+            return;
         }
+
+        throw new InvalidOptionsException("No recognised command was specified");
     }
 
     private static ChangeLogLanguage WithAdditionalSections(
@@ -422,6 +453,12 @@ internal static class Program
             ParserResult<Options> parser = await ParseOptionsAsync(args, serviceProvider);
 
             return parser.Tag == ParserResultType.Parsed ? SUCCESS : ERROR;
+        }
+        catch (InvalidOptionsException exception)
+        {
+            Console.WriteLine($"ERROR: {exception.Message}");
+
+            return ERROR;
         }
         catch (Exception exception)
         {


### PR DESCRIPTION
## Summary

Placeholder PR for issue #324 — implementation follows in a subsequent commit per the approved plan.

## Implementation Plan

See the approved plan posted on the issue for full details:
- Add explicit validation for partial option combinations (`--add`/`--remove` without `--message`, `--extract` without `--version`, `--version` without `--extract`) throwing `InvalidOptionsException`.
- Throw `InvalidOptionsException` when no recognised command was specified.
- Add a specific `catch (InvalidOptionsException)` in `Main` before the general `catch (Exception)`.
- Add tests covering each incomplete combination.

Closes #324