### PR TITLE
fix: ChangeLogParser crash on malformed version headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Provide properly translated section names and unreleased section labels for Czech, Danish, German, Spanish, French, Italian, Dutch, Chinese Simplified, and Chinese Traditional — these were incorrectly using English section order
 - ChangeLogDetector no longer reports 'changelog not found' due to access errors in nested directories; checks root CHANGELOG.md first without a full directory scan
 - CLI no longer silently exits 0 when required option combinations are incomplete (--add/--remove without --message, --extract without --version, --version without --extract, or no recognised command) — it now throws InvalidOptionsException and exits with a non-zero code.
+- Fix ChangeLogParser crash (ArgumentOutOfRangeException) on version headers with a missing closing bracket or malformed date separator
 ### Changed
 - ChangeLogSections: added static FrozenSet<string> KnownSections pre-built from Order, replacing per-call HashSet allocation in BuildNewUnreleasedContent
 - Refined changelog section linting and related updater/fixer command behaviour.

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogParserVersionHeaderTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogParserVersionHeaderTests.cs
@@ -1,0 +1,104 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.ChangeLog.Exceptions;
+using Credfeto.ChangeLog.Models;
+using Credfeto.ChangeLog.Services;
+using Credfeto.ChangeLog.Tests.TestHelpers;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.ChangeLog.Tests;
+
+public sealed class ChangeLogParserVersionHeaderTests : TestBase
+{
+    private static string BuildChangeLog(string versionHeader) =>
+        $"""
+            # Changelog
+
+            ## [Unreleased]
+            ### Added
+
+            {versionHeader}
+            ### Added
+            - Something
+
+            ## [0.0.0] - Project created
+            """;
+
+    [Fact]
+    public Task ParseAsync_MissingClosingBracket_ThrowsInvalidChangeLogException()
+    {
+        string changeLog = BuildChangeLog("## [1.2.3 - 2024-01-01");
+
+        return Assert.ThrowsAsync<InvalidChangeLogException>(() => ChangeLogTestHelper.ParseAsync(changeLog).AsTask());
+    }
+
+    [Fact]
+    public async Task ParseAsync_NoDateNotYanked_ParsesEmptyDate()
+    {
+        string changeLog = BuildChangeLog("## [1.2.3]");
+
+        ChangeLogDocument document = await ChangeLogTestHelper.ParseAsync(changeLog);
+
+        ChangeLogRelease release = document.Releases[0];
+        Assert.Equal(expected: "1.2.3", actual: release.Version);
+        Assert.Equal(expected: string.Empty, actual: release.Date);
+        Assert.False(release.IsYanked, userMessage: "Expected release to not be yanked");
+    }
+
+    [Fact]
+    public async Task ParseAsync_DateOnlyNotYanked_ParsesDate()
+    {
+        string changeLog = BuildChangeLog("## [1.2.3] - 2024-01-01");
+
+        ChangeLogDocument document = await ChangeLogTestHelper.ParseAsync(changeLog);
+
+        ChangeLogRelease release = document.Releases[0];
+        Assert.Equal(expected: "1.2.3", actual: release.Version);
+        Assert.Equal(expected: "2024-01-01", actual: release.Date);
+        Assert.False(release.IsYanked, userMessage: "Expected release to not be yanked");
+    }
+
+    [Fact]
+    public async Task ParseAsync_YankedWithDate_ParsesDateAndYanked()
+    {
+        string changeLog = BuildChangeLog("## [1.2.3] - 2024-01-01 [YANKED]");
+
+        ChangeLogDocument document = await ChangeLogTestHelper.ParseAsync(changeLog);
+
+        ChangeLogRelease release = document.Releases[0];
+        Assert.Equal(expected: "1.2.3", actual: release.Version);
+        Assert.Equal(expected: "2024-01-01", actual: release.Date);
+        Assert.True(release.IsYanked, userMessage: "Expected release to be yanked");
+    }
+
+    [Fact]
+    public async Task ParseAsync_YankedWithoutDate_ParsesEmptyDateAndYanked()
+    {
+        string changeLog = BuildChangeLog("## [1.2.3] [YANKED]");
+
+        ChangeLogDocument document = await ChangeLogTestHelper.ParseAsync(changeLog);
+
+        ChangeLogRelease release = document.Releases[0];
+        Assert.Equal(expected: "1.2.3", actual: release.Version);
+        Assert.Equal(expected: string.Empty, actual: release.Date);
+        Assert.True(release.IsYanked, userMessage: "Expected release to be yanked");
+    }
+
+    [Fact]
+    public async Task RoundTrip_YankedWithoutDate_PreservesYankedAndEmptyDate()
+    {
+        string changeLog = BuildChangeLog("## [1.2.3] [YANKED]");
+
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+
+        ChangeLogDocument document = await ChangeLogTestHelper.ParseAsync(changeLog);
+        string serialised = await new ChangeLogSerialiser().SerialiseAsync(document, cancellationToken);
+        ChangeLogDocument reparsed = await ChangeLogTestHelper.ParseAsync(serialised);
+
+        ChangeLogRelease release = reparsed.Releases[0];
+        Assert.Equal(expected: "1.2.3", actual: release.Version);
+        Assert.Equal(expected: string.Empty, actual: release.Date);
+        Assert.True(release.IsYanked, userMessage: "Expected round-tripped release to still be yanked");
+    }
+}

--- a/src/Credfeto.ChangeLog/Helpers/Throws.cs
+++ b/src/Credfeto.ChangeLog/Helpers/Throws.cs
@@ -75,4 +75,10 @@ internal static class Throws
     {
         throw new InvalidChangeLogException($"Could not find {changeLogFileName}");
     }
+
+    [DoesNotReturn]
+    public static (string Version, string Date, bool IsYanked) MalformedVersionHeader(string line)
+    {
+        throw new InvalidChangeLogException($"Malformed version header (missing closing bracket): {line}");
+    }
 }

--- a/src/Credfeto.ChangeLog/Services/ChangeLogParser.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogParser.cs
@@ -221,16 +221,32 @@ internal sealed class ChangeLogParser : IChangeLogParser
             this.InTrailerMode = true;
         }
 
+        private const string YANKED_SUFFIX = "[YANKED]";
+
         private static (string Version, string Date, bool IsYanked) ParseVersionHeader(string line)
         {
             int closeBracket = line.IndexOf(value: ']', comparisonType: StringComparison.Ordinal);
+
+            if (closeBracket == -1)
+            {
+                return Throws.MalformedVersionHeader(line);
+            }
+
             string version = line[4..closeBracket];
-            string raw = closeBracket + 4 < line.Length ? line[(closeBracket + 4)..] : string.Empty;
+            string rest = line[(closeBracket + 1)..].Trim();
 
-            bool isYanked = raw.EndsWith(value: " [YANKED]", comparisonType: StringComparison.OrdinalIgnoreCase);
-            string date = isYanked ? raw[..^" [YANKED]".Length] : raw;
+            bool isYanked = rest.EndsWith(value: YANKED_SUFFIX, comparisonType: StringComparison.OrdinalIgnoreCase);
+            if (isYanked)
+            {
+                rest = rest[..^YANKED_SUFFIX.Length].Trim();
+            }
 
-            return (version, date, isYanked);
+            if (rest.StartsWith(value: '-'))
+            {
+                rest = rest[1..].Trim();
+            }
+
+            return (version, rest, isYanked);
         }
 
         public void FlushSection()


### PR DESCRIPTION
## Summary

`ChangeLogParser.ParseVersionHeader` currently assumes every `## [` line has a closing `]` and a fixed `] - ` separator before the date. A malformed header (missing `]`, or a non-`- ` separator) throws an unhandled `ArgumentOutOfRangeException` instead of a meaningful parse/lint error, and a yanked release without a date does not round-trip correctly.

This draft PR scaffolds the branch per the approved implementation plan (see issue comments). Implementation follows in subsequent commits per the PR workflow.

## Plan

See the approved `## Implementation Plan` comment on #323 for the full approach, files to change, and test strategy.

Closes #323