### PR TITLE
fix: CreateEmptyAsync no longer writes the full initial template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - ChangeLogDetector no longer reports 'changelog not found' due to access errors in nested directories; checks root CHANGELOG.md first without a full directory scan
 - CLI no longer silently exits 0 when required option combinations are incomplete (--add/--remove without --message, --extract without --version, --version without --extract, or no recognised command) — it now throws InvalidOptionsException and exits with a non-zero code.
 - Fix ChangeLogParser crash (ArgumentOutOfRangeException) on version headers with a missing closing bracket or malformed date separator
+- CreateEmptyAsync now writes the full initial changelog template (#334)
 ### Changed
 - ChangeLogSections: added static FrozenSet<string> KnownSections pre-built from Order, replacing per-call HashSet allocation in BuildNewUnreleasedContent
 - Refined changelog section linting and related updater/fixer command behaviour.

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogServiceMockTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogServiceMockTests.cs
@@ -216,7 +216,7 @@ public sealed class ChangeLogServiceMockTests : TestBase
             .SaveAsync(Arg.Any<string>(), Arg.Any<ChangeLogDocument>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.CompletedTask);
 
-        ChangeLogUpdater updater = new(storage);
+        ChangeLogUpdater updater = new(storage, new ChangeLogParser());
 
         string tempFile = System.IO.Path.GetTempFileName();
         try
@@ -252,7 +252,7 @@ public sealed class ChangeLogServiceMockTests : TestBase
             .SaveAsync(Arg.Any<string>(), Arg.Any<ChangeLogDocument>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.CompletedTask);
 
-        ChangeLogUpdater updater = new(storage);
+        ChangeLogUpdater updater = new(storage, new ChangeLogParser());
 
         string tempFile = System.IO.Path.GetTempFileName();
         try

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterAsyncFileTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterAsyncFileTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Credfeto.ChangeLog.Constants;
 using Credfeto.ChangeLog.Models;
 using Credfeto.ChangeLog.Services;
 using Credfeto.ChangeLog.Tests.TestHelpers;
@@ -104,7 +105,7 @@ public sealed class ChangeLogUpdaterAsyncFileTests : LoggingFolderCleanupTestBas
             .SaveAsync(Arg.Any<string>(), Arg.Any<ChangeLogDocument>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.CompletedTask);
 
-        ChangeLogUpdater updater = new(storage);
+        ChangeLogUpdater updater = new(storage, new ChangeLogParser());
 
         string tempFile = Path.Combine(this.TempFolder, "test.md");
         await File.WriteAllTextAsync(tempFile, string.Empty, cancellationTokenSource.Token);
@@ -149,7 +150,7 @@ public sealed class ChangeLogUpdaterAsyncFileTests : LoggingFolderCleanupTestBas
             .SaveAsync(Arg.Any<string>(), Arg.Any<ChangeLogDocument>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.CompletedTask);
 
-        ChangeLogUpdater updater = new(storage);
+        ChangeLogUpdater updater = new(storage, new ChangeLogParser());
 
         string tempFile = Path.Combine(this.TempFolder, "test-release.md");
 
@@ -186,6 +187,70 @@ public sealed class ChangeLogUpdaterAsyncFileTests : LoggingFolderCleanupTestBas
             content.Contains("[Unreleased]", StringComparison.Ordinal),
             userMessage: $"Expected empty changelog to contain [Unreleased] section, got:{Environment.NewLine}{content}"
         );
+    }
+
+    [Fact]
+    public async Task CreateEmptyAsyncCreatesFileMatchingTemplate()
+    {
+        using CancellationTokenSource cancellationTokenSource = new();
+
+        string fileName = Path.Combine(this.TempFolder, $"{Guid.NewGuid():N}.md");
+
+        IChangeLogUpdater updater = this._serviceProvider.GetRequiredService<IChangeLogUpdater>();
+
+        await updater.CreateEmptyAsync(
+            changeLogFileName: fileName,
+            language: Language,
+            cancellationToken: cancellationTokenSource.Token
+        );
+
+        string content = await File.ReadAllTextAsync(fileName, Encoding.UTF8, cancellationTokenSource.Token);
+        Assert.Equal(expected: TemplateFile.Build(Language), actual: content.Trim());
+    }
+
+    [Fact]
+    public async Task CreateEmptyAsyncParsedDocumentHasSeedRelease()
+    {
+        using CancellationTokenSource cancellationTokenSource = new();
+
+        string fileName = Path.Combine(this.TempFolder, $"{Guid.NewGuid():N}.md");
+
+        IChangeLogUpdater updater = this._serviceProvider.GetRequiredService<IChangeLogUpdater>();
+
+        await updater.CreateEmptyAsync(
+            changeLogFileName: fileName,
+            language: Language,
+            cancellationToken: cancellationTokenSource.Token
+        );
+
+        string content = await File.ReadAllTextAsync(fileName, Encoding.UTF8, cancellationTokenSource.Token);
+        ChangeLogDocument document = await ChangeLogTestHelper.ParseAsync(content);
+
+        ChangeLogRelease release = Assert.Single(document.Releases);
+        Assert.Equal(expected: "0.0.0", actual: release.Version);
+        Assert.Equal(expected: "Project created", actual: release.Date);
+    }
+
+    [Fact]
+    public async Task CreateEmptyAsyncParsedDocumentHasTitle()
+    {
+        using CancellationTokenSource cancellationTokenSource = new();
+
+        string fileName = Path.Combine(this.TempFolder, $"{Guid.NewGuid():N}.md");
+
+        IChangeLogUpdater updater = this._serviceProvider.GetRequiredService<IChangeLogUpdater>();
+
+        await updater.CreateEmptyAsync(
+            changeLogFileName: fileName,
+            language: Language,
+            cancellationToken: cancellationTokenSource.Token
+        );
+
+        string content = await File.ReadAllTextAsync(fileName, Encoding.UTF8, cancellationTokenSource.Token);
+        ChangeLogDocument document = await ChangeLogTestHelper.ParseAsync(content);
+
+        Assert.Contains("# Changelog", document.HeaderLines);
+        Assert.Contains(TemplateFile.PreambleLine1, document.HeaderLines);
     }
 
     [Fact]

--- a/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Credfeto.ChangeLog.Constants;
 using Credfeto.ChangeLog.Exceptions;
 using Credfeto.ChangeLog.Extensions;
 using Credfeto.ChangeLog.Models;
@@ -21,21 +22,23 @@ namespace Credfeto.ChangeLog.Services;
 )]
 internal sealed class ChangeLogUpdater : IChangeLogUpdater
 {
+    private readonly IChangeLogParser _parser;
     private readonly IChangeLogStorage _storage;
 
-    public ChangeLogUpdater(IChangeLogStorage storage)
+    public ChangeLogUpdater(IChangeLogStorage storage, IChangeLogParser parser)
     {
         this._storage = storage;
+        this._parser = parser;
     }
 
-    public ValueTask CreateEmptyAsync(
+    public async ValueTask CreateEmptyAsync(
         string changeLogFileName,
         ChangeLogLanguage language,
         CancellationToken cancellationToken
     )
     {
-        ChangeLogDocument empty = BuildEmptyDocument(language);
-        return this._storage.SaveAsync(changeLogFileName, document: empty, cancellationToken: cancellationToken);
+        ChangeLogDocument empty = await this._parser.ParseAsync(TemplateFile.Build(language), cancellationToken);
+        await this._storage.SaveAsync(changeLogFileName, document: empty, cancellationToken: cancellationToken);
     }
 
     public async Task AddEntryAsync(
@@ -170,16 +173,6 @@ internal sealed class ChangeLogUpdater : IChangeLogUpdater
             sectionOrder: language.SectionOrder
         );
         return document with { Unreleased = unreleased with { Sections = ordered } };
-    }
-
-    private static ChangeLogDocument BuildEmptyDocument(ChangeLogLanguage language)
-    {
-        ImmutableArray<ChangeLogSection> sections =
-        [
-            .. language.SectionOrder.Select(name => new ChangeLogSection(Name: name, LineNumber: 0, Entries: [])),
-        ];
-        ChangeLogUnreleased unreleased = new(LineNumber: 0, Sections: sections, TrailingLines: []);
-        return new ChangeLogDocument(HeaderLines: [], Unreleased: unreleased, Releases: [], TrailingLines: []);
     }
 
     private async ValueTask<ChangeLogDocument> LoadOrCreateAsync(


### PR DESCRIPTION
## Summary

Before the `ChangeLogDocument` object-model refactor (#277), creating a missing changelog wrote the full `TemplateFile.Initial`/`TemplateFile.Build` template — title, guidance comments, unreleased sections, and the `0.0.0` seed release.

After the refactor, `ChangeLogUpdater.CreateEmptyAsync` builds a bare document via the private `BuildEmptyDocument` method, which has empty `HeaderLines` and no seed release. This means a changelog created from scratch is missing the `# Changelog` title, guidance comments, and the `0.0.0` seed release — and `--check-insert` fails on a freshly created changelog until a first release exists.

This PR will make `CreateEmptyAsync` parse `TemplateFile.Build(language)` through `IChangeLogParser` instead of building a bare document, so a freshly created changelog matches the full template.

## Plan

See the approved [Implementation Plan](https://github.com/credfeto/credfeto-changlog-manager/issues/334#issuecomment-4915521777) on the linked issue.

Closes #334