### PR TITLE
fix: --lint --fix does not converge with multiple leading blank lines (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - CLI no longer silently exits 0 when required option combinations are incomplete (--add/--remove without --message, --extract without --version, --version without --extract, or no recognised command) — it now throws InvalidOptionsException and exits with a non-zero code.
 - Fix ChangeLogParser crash (ArgumentOutOfRangeException) on version headers with a missing closing bracket or malformed date separator
 - CreateEmptyAsync now writes the full initial changelog template (#334)
+- Fixed --lint --fix not converging in a single pass when a changelog section heading was followed by two or more blank lines
 ### Changed
 - ChangeLogSections: added static FrozenSet<string> KnownSections pre-built from Order, replacing per-call HashSet allocation in BuildNewUnreleasedContent
 - Refined changelog section linting and related updater/fixer command behaviour.

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs
@@ -96,6 +96,32 @@ public sealed partial class ChangeLogFixerTests : TestBase
     }
 
     [Fact]
+    public void MultipleBlankLinesAfterHeading_AreAllRemoved()
+    {
+        const string changeLog = """
+            # Changelog
+
+            ## [Unreleased]
+            ### Security
+            ### Added
+
+
+            - an entry
+            ### Fixed
+            ### Changed
+            ### Removed
+            ### Deployment Changes
+
+            ## [0.0.0] - Project created
+            """;
+
+        string result = Serialise(ChangeLogFixer.Fix(Parse(changeLog), Language));
+
+        IReadOnlyList<LintError> errors = ChangeLogLinter.Lint(Parse(result), Language);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void MissingRequiredSection_IsAdded()
     {
         const string changeLog = """

--- a/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs
@@ -130,11 +130,20 @@ internal sealed class ChangeLogFixer : IChangeLogFixer
         };
     }
 
-    private static ChangeLogSection RemoveLeadingBlank(ChangeLogSection section) =>
-        section.Entries.Length > 0 && string.IsNullOrWhiteSpace(section.Entries[0])
-            ? section with
+    private static ChangeLogSection RemoveLeadingBlank(ChangeLogSection section)
+    {
+        int start = 0;
+
+        while (start < section.Entries.Length && string.IsNullOrWhiteSpace(section.Entries[start]))
+        {
+            start++;
+        }
+
+        return start == 0
+            ? section
+            : section with
             {
-                Entries = section.Entries[1..],
-            }
-            : section;
+                Entries = section.Entries[start..],
+            };
+    }
 }


### PR DESCRIPTION
## Summary

`ChangeLogFixer.RemoveLeadingBlank` (src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs) removed exactly one leading blank entry per section. The corresponding lint check `ChangeLogLinter.HasLeadingBlank` flags a section whose first entry is blank (when a non-blank entry follows). With two or more blank lines between a heading and its first entry, a single `--lint --fix` run removed only one blank, the re-lint in `Program.FixAndRelintAsync` still found the error, and the command exited 1 — even though it was asked to fix.

`RemoveLeadingBlank` now skips past all consecutive leading blank entries in one pass (mirroring the existing `TrimTrailingBlanks` pattern), so a single fix pass converges regardless of how many blank lines follow a heading.

## Changes

- `src/Credfeto.ChangeLog/Services/ChangeLogFixer.cs` — `RemoveLeadingBlank` now strips all consecutive leading blank entries instead of only the first one.
- `src/Credfeto.ChangeLog.Tests/ChangeLogFixerTests.cs` — added `MultipleBlankLinesAfterHeading_AreAllRemoved`, covering a heading followed by two blank lines, asserting lint is clean after a single fix.
- `CHANGELOG.md` — added entry via `dotnet changelog`.

## Test plan

- [x] `dotnet buildcheck` passes
- [x] Full test suite passes (940 tests)
- [x] New test reproduces the non-convergence bug and passes with the fix

See the approved [Implementation Plan](https://github.com/credfeto/credfeto-changlog-manager/issues/326#issuecomment-4938300922) on the issue for full details.

Closes #326