### PR TITLE
Drop net9.0: target net10.0 only (single TargetFramework)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Exposed changelog parser, serialiser, reader, linter, fixer, updater and detector services (previously internal) as public API, along with related helper types, so tests exercise them directly instead of via InternalsVisibleTo
 - Dependencies - Updated FunFair.Test to 6.3.6.2484
 - Dependencies - Updated Meziantou.Analyzer to 3.0.124
+- Dropped net9.0 support - now targets net10.0 only
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.ChangeLog.BenchMark.Tests/Credfeto.ChangeLog.BenchMark.Tests.csproj
+++ b/src/Credfeto.ChangeLog.BenchMark.Tests/Credfeto.ChangeLog.BenchMark.Tests.csproj
@@ -29,7 +29,7 @@
     <OutputType>Exe</OutputType>
     <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.ChangeLog.Cmd.Tests/Credfeto.ChangeLog.Cmd.Tests.csproj
+++ b/src/Credfeto.ChangeLog.Cmd.Tests/Credfeto.ChangeLog.Cmd.Tests.csproj
@@ -29,7 +29,7 @@
     <OutputType>Exe</OutputType>
     <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.ChangeLog.Cmd/Credfeto.ChangeLog.Cmd.csproj
+++ b/src/Credfeto.ChangeLog.Cmd/Credfeto.ChangeLog.Cmd.csproj
@@ -45,7 +45,7 @@
     <RepositoryUrl>https://github.com/credfeto/changelog-manager</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <ToolCommandName>changelog</ToolCommandName>

--- a/src/Credfeto.ChangeLog.Tests/Credfeto.ChangeLog.Tests.csproj
+++ b/src/Credfeto.ChangeLog.Tests/Credfeto.ChangeLog.Tests.csproj
@@ -29,7 +29,7 @@
     <OutputType>Exe</OutputType>
     <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.ChangeLog/Credfeto.ChangeLog.csproj
+++ b/src/Credfeto.ChangeLog/Credfeto.ChangeLog.csproj
@@ -42,7 +42,7 @@
     <RepositoryUrl>https://github.com/credfeto/changelog-manager</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary

Drops `net9.0` from every multi-targeted `.csproj` so the repository targets `net10.0` only, per the approved implementation plan on #350.

## Scope

- `src/Credfeto.ChangeLog.BenchMark.Tests/Credfeto.ChangeLog.BenchMark.Tests.csproj`
- `src/Credfeto.ChangeLog.Cmd.Tests/Credfeto.ChangeLog.Cmd.Tests.csproj`
- `src/Credfeto.ChangeLog.Cmd/Credfeto.ChangeLog.Cmd.csproj`
- `src/Credfeto.ChangeLog.Tests/Credfeto.ChangeLog.Tests.csproj`
- `src/Credfeto.ChangeLog/Credfeto.ChangeLog.csproj`

This draft currently contains only a placeholder CHANGELOG.md entry; the `TargetFrameworks` to `TargetFramework` changes and any related dead-code cleanup land in follow-up commits under the pull-request workflow.

Closes #350