### PR TITLE
fix: correct repository URL references to credfeto-changelog-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 - Changelog linter now rejects release dates that don't match the configured language format, including previously-accepted garbage values
+- Correct repository URL references to the canonical credfeto-changelog-manager repo name
 ### Changed
 - Dependencies - Updated AsyncFixer to 2.1.0
 - Dependencies - Updated Credfeto.Enumeration to 1.2.151.2192

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Changelog manager is a .net tool that works on all supported .net platforms (win
 
 ## Build Status
 
-| Branch  | Status                                                                                                                                                                                                                                  |
-|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| main    | [![Build: Pre-Release](https://github.com/credfeto/changelog-manager/actions/workflows/build-and-publish-pre-release.yml/badge.svg)](https://github.com/credfeto/changelog-manager/actions/workflows/build-and-publish-pre-release.yml) |
-| release | [![Build: Release](https://github.com/credfeto/changelog-manager/actions/workflows/build-and-publish-release.yml/badge.svg)](https://github.com/credfeto/changelog-manager/actions/workflows/build-and-publish-release.yml)             |
+| Branch  | Status                                                                                                                                                                                                                                                    |
+|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| main    | [![Build: Pre-Release](https://github.com/credfeto/credfeto-changelog-manager/actions/workflows/build-and-publish-pre-release.yml/badge.svg)](https://github.com/credfeto/credfeto-changelog-manager/actions/workflows/build-and-publish-pre-release.yml) |
+| release | [![Build: Release](https://github.com/credfeto/credfeto-changelog-manager/actions/workflows/build-and-publish-release.yml/badge.svg)](https://github.com/credfeto/credfeto-changelog-manager/actions/workflows/build-and-publish-release.yml)             |
 
 ## Release Notes
 

--- a/src/Credfeto.ChangeLog.Cmd/Credfeto.ChangeLog.Cmd.csproj
+++ b/src/Credfeto.ChangeLog.Cmd/Credfeto.ChangeLog.Cmd.csproj
@@ -42,7 +42,7 @@
     <Product>Changelog management tool</Product>
     <PublishAot>false</PublishAot>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/credfeto/changelog-manager</RepositoryUrl>
+    <RepositoryUrl>https://github.com/credfeto/credfeto-changelog-manager</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <TargetFramework>net10.0</TargetFramework>

--- a/src/Credfeto.ChangeLog/Credfeto.ChangeLog.csproj
+++ b/src/Credfeto.ChangeLog/Credfeto.ChangeLog.csproj
@@ -39,7 +39,7 @@
     <PackageTags>Changelog</PackageTags>
     <Product>Changelog management tool</Product>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/credfeto/changelog-manager</RepositoryUrl>
+    <RepositoryUrl>https://github.com/credfeto/credfeto-changelog-manager</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFramework>net10.0</TargetFramework>


### PR DESCRIPTION
## Summary
- RepositoryUrl in both csproj files and the README build-status badges pointed at `github.com/credfeto/changelog-manager`, which is only a GitHub rename redirect
- The canonical repo (confirmed via `gh api repos/credfeto/changelog-manager`) is `credfeto-changelog-manager`
- Also updated the local git remote to the canonical URL

## Test plan
- [x] `dotnet build` succeeds
- [x] Pre-commit hooks (markdownlint, changelog lint, buildcheck) passed