### PR TITLE
perf: hoist loop-invariant Version.TryParse out of ValidateVersionNotExists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Dependencies - Updated Meziantou.Analyzer to 3.0.156
 - Dependencies - Updated xunit.analyzers to 2.0.0
 - Dependencies - Updated xunit.v3 to 4.0.0
+- TBD - to be finalized after review (issue #336)
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Dependencies - Updated Meziantou.Analyzer to 3.0.156
 - Dependencies - Updated xunit.analyzers to 2.0.0
 - Dependencies - Updated xunit.v3 to 4.0.0
-- TBD - to be finalized after review (issue #336)
+- ChangeLogUpdater - Hoisted the loop-invariant requested-version parse out of ValidateVersionNotExists so it is parsed once per --create-release invocation instead of once per existing release
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -24,4 +24,4 @@ excluded
 
 ---
 
-Captured at commit `e8137c9e842da6b9eefb3119aaec0c4b292f9f10` on 2026-08-18.
+Captured at commit `f5b7229ca2cd1eb2599a57999f710a4cd25fa954` on 2026-08-19.

--- a/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
@@ -252,6 +252,8 @@ public sealed class ChangeLogUpdater : IChangeLogUpdater
     )]
     private static void ValidateVersionNotExists(in ImmutableArray<ChangeLogRelease> releases, string version)
     {
+        bool requestedParsed = Version.TryParse(version, out Version? requested);
+
         foreach (ChangeLogRelease release in releases)
         {
             if (release.Version.EqualsOrdinal(version))
@@ -259,11 +261,7 @@ public sealed class ChangeLogUpdater : IChangeLogUpdater
                 throw new ReleaseAlreadyExistsException($"Release {version} already exists");
             }
 
-            if (
-                Version.TryParse(release.Version, out Version? existing)
-                && Version.TryParse(version, out Version? requested)
-                && existing > requested
-            )
+            if (requestedParsed && Version.TryParse(release.Version, out Version? existing) && existing > requested)
             {
                 throw new ReleaseTooOldException(
                     $"Release {release.Version} already exists and is newer than {version}"


### PR DESCRIPTION
## Summary

`ChangeLogUpdater.ValidateVersionNotExists` currently calls `Version.TryParse(version, out Version? requested)` inside the `foreach` over existing releases, re-parsing the loop-invariant requested version once per release. This hoists that parse above the loop so it only happens once per `--create-release` invocation.

This PR currently contains only a placeholder CHANGELOG.md entry; the code change follows in a subsequent commit per the approved implementation plan on #336.

Closes #336