### PR TITLE
fix: whitespace-only lines counted as release content in CreateRelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
-- TBD - to be finalized after review
+- BuildReleaseSections now excludes whitespace-only unreleased lines the same way it already excludes blank ones, so CreateRelease correctly throws EmptyChangeLogException instead of producing a release with only whitespace content
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- TBD - to be finalized after review
 ### Changed
 ### Deprecated
 ### Removed

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -24,4 +24,4 @@ excluded
 
 ---
 
-Captured at commit `be33a67a76206f9343674a2d8e1e1dbb9659b216` on 2026-08-25.
+Captured at commit `248c6b560ab5d2d6f3b2a71a399fa88802566de5` on 2026-08-26.

--- a/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterCreateRelease.cs
+++ b/src/Credfeto.ChangeLog.Tests/ChangeLogUpdaterCreateRelease.cs
@@ -78,6 +78,35 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
     }
 
     [Fact]
+    public void UnreleasedWithOnlyWhitespaceEntriesDoesNotCreateARelease()
+    {
+        string changeLog =
+            $@"# Changelog
+All notable changes to this project will be documented in this file.
+
+<!--
+Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
+-->
+
+## [Unreleased]
+### Added
+{"   "}
+### Fixed
+### Changed
+### Removed
+### Deployment Changes
+
+<!--
+Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
+-->
+## [0.0.0] - Project created";
+
+        Assert.Throws<EmptyChangeLogException>(() =>
+            ChangeLogUpdater.CreateRelease(Parse(changeLog), "1.0.0", true, Language)
+        );
+    }
+
+    [Fact]
     public void CannotCreateAReleaseThatAlreadyExists()
     {
         const string changeLog =
@@ -157,6 +186,62 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Added
 - Some Content
+### Fixed
+### Changed
+### Removed
+### Deployment Changes
+
+<!--
+Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
+-->
+## [0.0.0] - Project created";
+
+        string updated = Serialise(ChangeLogUpdater.CreateRelease(Parse(changeLog), "1.0.0", true, Language));
+
+        const string expected =
+            @"# Changelog
+All notable changes to this project will be documented in this file.
+
+<!--
+Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
+-->
+
+## [Unreleased]
+### Added
+### Fixed
+### Changed
+### Removed
+### Deployment Changes
+
+<!--
+Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch
+-->
+
+## [1.0.0] - TBD
+### Added
+- Some Content
+
+## [0.0.0] - Project created";
+
+        this._output.WriteLine(updated);
+        Assert.Equal(expected.ToLocalEndLine(), actual: updated);
+    }
+
+    [Fact]
+    public void ChangeLogWithWhitespaceOnlyEntryExcludesItFromRelease()
+    {
+        string changeLog =
+            $@"# Changelog
+All notable changes to this project will be documented in this file.
+
+<!--
+Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
+-->
+
+## [Unreleased]
+### Added
+- Some Content
+{"   "}
 ### Fixed
 ### Changed
 ### Removed

--- a/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
+++ b/src/Credfeto.ChangeLog/Services/ChangeLogUpdater.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -294,7 +294,10 @@ public sealed class ChangeLogUpdater : IChangeLogUpdater
 
         foreach (ChangeLogSection s in sections)
         {
-            ImmutableArray<string> entries = [.. s.Entries.AsValueEnumerable().Where(e => !string.IsNullOrEmpty(e))];
+            ImmutableArray<string> entries =
+            [
+                .. s.Entries.AsValueEnumerable().Where(e => !string.IsNullOrWhiteSpace(e)),
+            ];
 
             if (entries.Length > 0)
             {


### PR DESCRIPTION
## Summary

Draft PR opened with a placeholder changelog entry to track work on #335. Implementation follows in the pull-request workflow.

### Problem

`ChangeLogUpdater.BuildReleaseSections` filters unreleased entries with `!string.IsNullOrEmpty(e)`, while the rest of the class treats blank content with `string.IsNullOrWhiteSpace`. A whitespace-only line therefore survives into a created release instead of being excluded, and `CreateRelease` fails to throw `EmptyChangeLogException` when the unreleased section only contains such lines.

### Planned approach

Use `string.IsNullOrWhiteSpace` in `BuildReleaseSections`, matching the convention used elsewhere (`FindInsertPosition`, `TrimTrailingBlanks`/`MoveTrailingBlanks`), and add parameterised test coverage for whitespace-only and mixed real/whitespace unreleased sections.

Closes #335